### PR TITLE
[BOUNTY] Redesigned pin entry view controller (part 1/3)

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		26BB0291965990A98D4BF0BB /* Pods_BlockEQTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89B1C324671F6269D8DB10A7 /* Pods_BlockEQTests.framework */; };
 		A6066F61786CC7405A06A52A /* Pods_BlockEQ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2BFC2D9DF7C32F6D40C804F /* Pods_BlockEQ.framework */; };
 		BCB2B19D8A0C42DDC9D826C1 /* Pods_BlockEQUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6912708A90B522F68A7AFA11 /* Pods_BlockEQUITests.framework */; };
+		C525C97920B79695006C138F /* KeyboardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = C525C97820B79695006C138F /* KeyboardView.xib */; };
+		C525C97B20B79890006C138F /* KeyboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C525C97A20B79890006C138F /* KeyboardView.swift */; };
 		C553ACBC2091572800B2379B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = C553ACBA2091572800B2379B /* Localizable.strings */; };
 		C589FF2A20902CCC00F5F308 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C589FF2920902CCC00F5F308 /* SettingsViewController.swift */; };
 		C589FF2C20902CE300F5F308 /* SettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C589FF2B20902CE300F5F308 /* SettingsViewController.xib */; };
@@ -110,6 +112,8 @@
 		6978359A021C7947F1C6AC48 /* Pods-BlockEQTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlockEQTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BlockEQTests/Pods-BlockEQTests.release.xcconfig"; sourceTree = "<group>"; };
 		89B1C324671F6269D8DB10A7 /* Pods_BlockEQTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BlockEQTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2BFC2D9DF7C32F6D40C804F /* Pods_BlockEQ.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BlockEQ.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C525C97820B79695006C138F /* KeyboardView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = KeyboardView.xib; sourceTree = "<group>"; };
+		C525C97A20B79890006C138F /* KeyboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardView.swift; sourceTree = "<group>"; };
 		C553ACBB2091572800B2379B /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C589FF2920902CCC00F5F308 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		C589FF2B20902CE300F5F308 /* SettingsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsViewController.xib; sourceTree = "<group>"; };
@@ -429,6 +433,8 @@
 				EC2015F220531875009A73C8 /* PinView.xib */,
 				EC2015F620532F4B009A73C8 /* AppButton.swift */,
 				EC20160020536C68009A73C8 /* PillView.swift */,
+				C525C97820B79695006C138F /* KeyboardView.xib */,
+				C525C97A20B79890006C138F /* KeyboardView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -605,6 +611,7 @@
 				EC1CEE5420577E880005F74E /* WordSuggestionCell.xib in Resources */,
 				C5E8594B20AFB47900B77289 /* AppTabController.xib in Resources */,
 				EC4258502054EE76000941B5 /* SendAmountViewController.xib in Resources */,
+				C525C97920B79695006C138F /* KeyboardView.xib in Resources */,
 				EC2015B32052D968009A73C8 /* LaunchScreen.storyboard in Resources */,
 				EC2015EA2052EAC7009A73C8 /* WalletTitleViewController.xib in Resources */,
 				C589FF2C20902CE300F5F308 /* SettingsViewController.xib in Resources */,
@@ -757,6 +764,7 @@
 				EC1CEE4F205774E70005F74E /* VerificationViewController.swift in Sources */,
 				EC72C0B22059742900141D6F /* KeychainHelper.swift in Sources */,
 				EC2015E22052E6B6009A73C8 /* UIColor+Gradient.swift in Sources */,
+				C525C97B20B79890006C138F /* KeyboardView.swift in Sources */,
 				C5AB413120902F7500096A29 /* String+Localization.swift in Sources */,
 				C5E8594E20AFCC0E00B77289 /* ApplicationCoordinator.swift in Sources */,
 			);

--- a/BlockEQ/View Controllers/Wallet Creation and Restoration/PinViewController.xib
+++ b/BlockEQ/View Controllers/Wallet Creation and Restoration/PinViewController.xib
@@ -1,25 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PinViewController" customModule="BlockEQ" customModuleProvider="target">
             <connections>
-                <outlet property="buttonHolderView" destination="LLn-7s-cPf" id="Mei-dB-hkt"/>
-                <outlet property="nextButton" destination="0Oo-io-3Gj" id="kYq-Bo-NY2"/>
+                <outlet property="keyboardView" destination="Ltc-UM-qNc" id="i74-pq-WA8"/>
                 <outlet property="pinView1" destination="zYp-gE-uWy" id="UFO-yA-IXg"/>
                 <outlet property="pinView2" destination="dzt-LG-dPx" id="Zn3-vo-MLU"/>
                 <outlet property="pinView3" destination="pc4-JF-xCR" id="h1z-ey-Hhe"/>
                 <outlet property="pinView4" destination="v34-ap-m1f" id="Ssy-mE-S0N"/>
                 <outlet property="pinViewHolder" destination="RfV-TG-cay" id="Tjf-WE-1Ez"/>
-                <outlet property="textField" destination="DM4-MA-87l" id="Yhr-dY-ETW"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -31,16 +28,6 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wqb-C1-HGh">
                     <rect key="frame" x="16" y="70" width="343" height="70"/>
                     <subviews>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="DM4-MA-87l">
-                            <rect key="frame" x="0.0" y="0.0" width="343" height="70"/>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <color key="textColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
-                            <connections>
-                                <action selector="textFieldDidChange" destination="-1" eventType="editingChanged" id="9wl-Mw-TXc"/>
-                            </connections>
-                        </textField>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RfV-TG-cay">
                             <rect key="frame" x="0.0" y="0.0" width="343" height="70"/>
                             <subviews>
@@ -88,52 +75,26 @@
                         <constraint firstAttribute="trailing" secondItem="RfV-TG-cay" secondAttribute="trailing" id="NuQ-jv-0vr"/>
                         <constraint firstItem="RfV-TG-cay" firstAttribute="top" secondItem="wqb-C1-HGh" secondAttribute="top" id="Ytb-ed-v1F"/>
                         <constraint firstAttribute="height" constant="70" id="eAF-NX-eag"/>
-                        <constraint firstAttribute="bottom" secondItem="DM4-MA-87l" secondAttribute="bottom" id="htn-bm-4is"/>
                         <constraint firstItem="RfV-TG-cay" firstAttribute="leading" secondItem="wqb-C1-HGh" secondAttribute="leading" id="n39-63-C3n"/>
-                        <constraint firstItem="DM4-MA-87l" firstAttribute="top" secondItem="wqb-C1-HGh" secondAttribute="top" id="nOA-pK-RhK"/>
-                        <constraint firstAttribute="trailing" secondItem="DM4-MA-87l" secondAttribute="trailing" id="tLS-EG-dbd"/>
-                        <constraint firstItem="DM4-MA-87l" firstAttribute="leading" secondItem="wqb-C1-HGh" secondAttribute="leading" id="yth-yL-qqD"/>
                     </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ltc-UM-qNc" customClass="KeyboardView" customModule="BlockEQ" customModuleProvider="target">
+                    <rect key="frame" x="25" y="240" width="325" height="377"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
             </subviews>
             <color key="backgroundColor" red="0.96862745098039216" green="0.96862745098039216" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Ltc-UM-qNc" secondAttribute="trailing" constant="25" id="2AW-bx-em7"/>
                 <constraint firstItem="wqb-C1-HGh" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="585-nR-EiP"/>
+                <constraint firstItem="Ltc-UM-qNc" firstAttribute="top" secondItem="wqb-C1-HGh" secondAttribute="bottom" constant="100" id="Hf2-op-G1O"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="wqb-C1-HGh" secondAttribute="trailing" constant="16" id="OuN-zs-eGe"/>
                 <constraint firstItem="wqb-C1-HGh" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="50" id="U9c-fS-WIY"/>
+                <constraint firstItem="Ltc-UM-qNc" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="25" id="j2b-iw-YbM"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="Ltc-UM-qNc" secondAttribute="bottom" constant="50" id="nFX-dv-tTd"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="33.5" y="53.5"/>
-        </view>
-        <view contentMode="scaleToFill" id="LLn-7s-cPf">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <subviews>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Oo-io-3Gj" customClass="AppButton" customModule="BlockEQ" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="50" id="otW-Mo-XhB"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
-                    <state key="normal" title="Next">
-                        <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    </state>
-                    <connections>
-                        <action selector="selectNext" destination="-1" eventType="touchUpInside" id="ilS-hL-f0b"/>
-                    </connections>
-                </button>
-            </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-            <constraints>
-                <constraint firstItem="0Oo-io-3Gj" firstAttribute="leading" secondItem="g0h-0G-4z4" secondAttribute="leading" id="Dff-ne-On2"/>
-                <constraint firstItem="0Oo-io-3Gj" firstAttribute="top" secondItem="LLn-7s-cPf" secondAttribute="top" id="L9K-Zp-yBa"/>
-                <constraint firstItem="g0h-0G-4z4" firstAttribute="trailing" secondItem="0Oo-io-3Gj" secondAttribute="trailing" id="aEU-Ab-q7B"/>
-                <constraint firstAttribute="bottom" secondItem="0Oo-io-3Gj" secondAttribute="bottom" id="kG8-LU-HGa"/>
-            </constraints>
-            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="g0h-0G-4z4"/>
-            <point key="canvasLocation" x="34" y="508"/>
         </view>
     </objects>
 </document>

--- a/BlockEQ/Views/KeyboardView.swift
+++ b/BlockEQ/Views/KeyboardView.swift
@@ -1,0 +1,153 @@
+//
+//  KeyboardView.swift
+//  BlockEQ
+//
+//  Created by Nick DiZazzo on 2018-05-24.
+//  Copyright © 2018 Satraj Bambra. All rights reserved.
+//
+
+import Foundation
+
+enum KeyboardButton {
+    case number(Int)
+    case left, right
+    case unrecognized
+}
+
+protocol KeyboardViewDelegate: AnyObject {
+    func selected(key: KeyboardButton, action: UIEvent)
+}
+
+struct KeyboardOptions: OptionSet {
+    let rawValue: Int
+    static let keyLabels = KeyboardOptions(rawValue: 1 << 0)
+    static let leftButton = KeyboardOptions(rawValue: 1 << 1)
+    static let rightButton = KeyboardOptions(rawValue: 1 << 2)
+    static let all: KeyboardOptions = [.keyLabels, .leftButton, .rightButton]
+}
+
+struct KeyboardViewModel {
+    var options: KeyboardOptions
+    var buttons: [(title: String, label: String)]
+    var bottomLeftImage: UIImage?
+    var bottomRightImage: UIImage?
+
+    var labelColor: UIColor
+    var buttonColor: UIColor
+    var backgroundColor: UIColor
+}
+
+class KeyboardView: UIView {
+    @IBOutlet var contentView: UIView!
+
+    weak var delegate: KeyboardViewDelegate?
+
+    /// The numeric buttons in the view, from top left to bottom right
+    @IBOutlet var keyButtons: [UIButton]!
+
+    /// The labels for the numeric buttons in the view, from top left to bottom right
+    @IBOutlet var keyLabels: [UILabel]!
+
+    /// The button on the bottom left
+    @IBOutlet weak var leftConfigurableButton: UIButton!
+
+    /// The button on the bottom right
+    @IBOutlet weak var rightConfigurableButton: UIButton!
+
+    /// The label for the button on the bottom left
+    @IBOutlet weak var leftConfigurableLabel: UILabel!
+
+    /// The label for the button on the bottom right
+    @IBOutlet weak var rightConfigurableLabel: UILabel!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    func commonInit() {
+        Bundle.main.loadNibNamed("KeyboardView", owner: self, options: nil)
+        addSubview(contentView)
+        contentView.frame = self.bounds
+        contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+        self.backgroundColor = .clear
+    }
+
+    /// The action when any button is pressed in the KeyboardView
+    ///
+    /// - Parameters:
+    ///   - sender: The UIButton triggering this action.
+    ///   - event: The UIEvent received.
+    @IBAction func selectedButton(_ sender: Any, forEvent event: UIEvent) {
+        guard let button = sender as? UIButton else {
+            return
+        }
+
+        var key: KeyboardButton
+
+        switch button {
+        case _ where button == keyButtons[0]: key = .number(1)
+        case _ where button == keyButtons[1]: key = .number(2)
+        case _ where button == keyButtons[2]: key = .number(3)
+        case _ where button == keyButtons[3]: key = .number(4)
+        case _ where button == keyButtons[4]: key = .number(5)
+        case _ where button == keyButtons[5]: key = .number(6)
+        case _ where button == keyButtons[6]: key = .number(7)
+        case _ where button == keyButtons[7]: key = .number(8)
+        case _ where button == keyButtons[8]: key = .number(9)
+        case _ where button == keyButtons[10]: key = .number(0)
+        case _ where button == leftConfigurableButton: key = .left
+        case _ where button == rightConfigurableButton: key = .right
+        default: key = .unrecognized
+        }
+
+        delegate?.selected(key: key, action: event)
+    }
+
+    /// Configures the KeyboardView with the provided options
+    ///
+    /// - Parameter viewModel: The configuration model for the keyboard view.
+    func update(with viewModel: KeyboardViewModel) {
+        assert(keyButtons.count == viewModel.buttons.count, "Mismatched label count!")
+        assert(keyLabels.count == viewModel.buttons.count, "Mismatched title count!")
+
+        for label in keyLabels.enumerated() {
+            keyLabels[label.offset].text = viewModel.buttons[label.offset].label
+            keyLabels[label.offset].isHidden = !viewModel.options.contains(.keyLabels)
+            keyLabels[label.offset].textColor = viewModel.labelColor
+        }
+
+        for button in keyButtons.enumerated() {
+            keyButtons[button.offset].setTitle(viewModel.buttons[button.offset].title, for: .normal)
+            keyButtons[button.offset].setTitleColor(viewModel.buttonColor, for: .normal)
+        }
+
+        let leftHidden = !viewModel.options.contains(.leftButton)
+        leftConfigurableButton.isHidden = leftHidden
+        leftConfigurableLabel.isHidden = leftHidden
+        leftConfigurableButton.setImage(viewModel.bottomLeftImage, for: .normal)
+        leftConfigurableButton.tintColor = viewModel.buttonColor
+
+        let rightHidden = !viewModel.options.contains(.rightButton)
+        rightConfigurableButton.isHidden = rightHidden
+        rightConfigurableLabel.isHidden = rightHidden
+        rightConfigurableButton.setImage(viewModel.bottomRightImage, for: .normal)
+        rightConfigurableButton.tintColor = viewModel.buttonColor
+
+        if viewModel.bottomLeftImage != nil {
+            leftConfigurableButton.setTitle(nil, for: .normal)
+        }
+
+        if viewModel.bottomRightImage != nil {
+            rightConfigurableButton.setTitle(nil, for: .normal)
+        }
+
+        backgroundColor = viewModel.backgroundColor
+    }
+}

--- a/BlockEQ/Views/KeyboardView.xib
+++ b/BlockEQ/Views/KeyboardView.xib
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="KeyboardView" customModule="BlockEQ" customModuleProvider="target">
+            <connections>
+                <outlet property="contentView" destination="iN0-l3-epB" id="iQy-tY-061"/>
+                <outlet property="leftConfigurableButton" destination="p90-mV-N7b" id="0QO-Y1-X88"/>
+                <outlet property="leftConfigurableLabel" destination="mmm-rb-uRs" id="oMs-m8-5Ef"/>
+                <outlet property="rightConfigurableButton" destination="2CL-l8-eOm" id="K3h-fu-MXX"/>
+                <outlet property="rightConfigurableLabel" destination="TXZ-BI-yjD" id="GQv-P6-dHC"/>
+                <outletCollection property="keyButtons" destination="Rat-0b-8SN" collectionClass="NSMutableArray" id="kyR-dO-Qat"/>
+                <outletCollection property="keyButtons" destination="wKZ-fv-2Cr" collectionClass="NSMutableArray" id="Xue-cG-0Rp"/>
+                <outletCollection property="keyButtons" destination="icA-0s-sAx" collectionClass="NSMutableArray" id="woN-fg-Ba7"/>
+                <outletCollection property="keyButtons" destination="isW-hz-UL3" collectionClass="NSMutableArray" id="6Ow-JD-Lca"/>
+                <outletCollection property="keyButtons" destination="h8H-VR-qrX" collectionClass="NSMutableArray" id="ioo-7W-TC2"/>
+                <outletCollection property="keyButtons" destination="Kie-Da-7F1" collectionClass="NSMutableArray" id="8vl-YL-deD"/>
+                <outletCollection property="keyButtons" destination="YOG-7B-Gao" collectionClass="NSMutableArray" id="gCW-TJ-aA5"/>
+                <outletCollection property="keyButtons" destination="plD-sM-fHP" collectionClass="NSMutableArray" id="Xli-H2-MF9"/>
+                <outletCollection property="keyButtons" destination="TZi-ya-q8V" collectionClass="NSMutableArray" id="Owt-li-QNy"/>
+                <outletCollection property="keyButtons" destination="p90-mV-N7b" collectionClass="NSMutableArray" id="5z7-jF-Ftm"/>
+                <outletCollection property="keyButtons" destination="Yvz-3j-zCD" collectionClass="NSMutableArray" id="Ldd-wD-fTd"/>
+                <outletCollection property="keyButtons" destination="2CL-l8-eOm" collectionClass="NSMutableArray" id="Vig-Pm-zio"/>
+                <outletCollection property="keyLabels" destination="RvE-9O-2KZ" collectionClass="NSMutableArray" id="xzT-eb-efl"/>
+                <outletCollection property="keyLabels" destination="VLA-zI-FYu" collectionClass="NSMutableArray" id="cFw-3n-2pO"/>
+                <outletCollection property="keyLabels" destination="buk-0a-3yU" collectionClass="NSMutableArray" id="KkS-HB-Pap"/>
+                <outletCollection property="keyLabels" destination="OR4-Tw-dWL" collectionClass="NSMutableArray" id="XB6-wQ-lFK"/>
+                <outletCollection property="keyLabels" destination="CeK-WW-fye" collectionClass="NSMutableArray" id="Urh-FF-aBW"/>
+                <outletCollection property="keyLabels" destination="8qo-su-Et1" collectionClass="NSMutableArray" id="QOj-Qg-mbt"/>
+                <outletCollection property="keyLabels" destination="SJL-La-7sS" collectionClass="NSMutableArray" id="KuR-PD-bKH"/>
+                <outletCollection property="keyLabels" destination="1Ae-8W-gda" collectionClass="NSMutableArray" id="Cj4-Lo-wCK"/>
+                <outletCollection property="keyLabels" destination="9Ad-Qx-B2z" collectionClass="NSMutableArray" id="98j-68-sVu"/>
+                <outletCollection property="keyLabels" destination="mmm-rb-uRs" collectionClass="NSMutableArray" id="ptb-hC-Kp5"/>
+                <outletCollection property="keyLabels" destination="PrX-zz-twe" collectionClass="NSMutableArray" id="svy-Bn-2zy"/>
+                <outletCollection property="keyLabels" destination="TXZ-BI-yjD" collectionClass="NSMutableArray" id="j5q-9u-9Z5"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="450"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Diy-VN-O4a" userLabel="Labels">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="450"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="bottom" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RvE-9O-2KZ" userLabel="1">
+                            <rect key="frame" x="45.5" y="78" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VLA-zI-FYu" userLabel="2">
+                            <rect key="frame" x="170.5" y="78" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="buk-0a-3yU" userLabel="3">
+                            <rect key="frame" x="295.5" y="78" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OR4-Tw-dWL" userLabel="4">
+                            <rect key="frame" x="45.5" y="190.5" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CeK-WW-fye" userLabel="5">
+                            <rect key="frame" x="170.5" y="190.5" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8qo-su-Et1" userLabel="6">
+                            <rect key="frame" x="295.5" y="190.5" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SJL-La-7sS" userLabel="7">
+                            <rect key="frame" x="45.5" y="303" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Ae-8W-gda" userLabel="8">
+                            <rect key="frame" x="170.5" y="303" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Ad-Qx-B2z" userLabel="9">
+                            <rect key="frame" x="295.5" y="303" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mmm-rb-uRs" userLabel="Left Configurable">
+                            <rect key="frame" x="45.5" y="415.5" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PrX-zz-twe" userLabel="0">
+                            <rect key="frame" x="170.5" y="415.5" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TXZ-BI-yjD" userLabel="Right Configurable">
+                            <rect key="frame" x="295.5" y="415.5" width="35" height="17"/>
+                            <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                </view>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="3Pm-9K-MUS" userLabel="Numbers">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="450"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="IHe-8h-Xk2">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="112.5"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rat-0b-8SN" userLabel="1">
+                                    <rect key="frame" x="0.0" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="1"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="EpO-fR-1KK"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wKZ-fv-2Cr" userLabel="2">
+                                    <rect key="frame" x="125" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="2"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="WvO-eT-LYP"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="icA-0s-sAx" userLabel="3">
+                                    <rect key="frame" x="250" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="3"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="x8a-Nr-cS3"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="j1z-bQ-1UP">
+                            <rect key="frame" x="0.0" y="112.5" width="375" height="112.5"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="isW-hz-UL3" userLabel="4">
+                                    <rect key="frame" x="0.0" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="4"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="gCH-gd-kbM"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h8H-VR-qrX" userLabel="5">
+                                    <rect key="frame" x="125" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="5"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="BX5-16-hlj"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kie-Da-7F1" userLabel="6">
+                                    <rect key="frame" x="250" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="6"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="2bY-9Y-Gzc"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="2JL-F6-ifr">
+                            <rect key="frame" x="0.0" y="225" width="375" height="112.5"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YOG-7B-Gao" userLabel="7">
+                                    <rect key="frame" x="0.0" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="7"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="pkJ-WW-H6A"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="plD-sM-fHP" userLabel="8">
+                                    <rect key="frame" x="125" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="8"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="oAW-Ev-0My"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TZi-ya-q8V" userLabel="9">
+                                    <rect key="frame" x="250" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="9"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="s8R-sx-Mkl"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Q2n-l1-apr">
+                            <rect key="frame" x="0.0" y="337.5" width="375" height="112.5"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p90-mV-N7b" userLabel="Left Configurable">
+                                    <rect key="frame" x="0.0" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="!"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="Vpi-1R-vTT"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yvz-3j-zCD" userLabel="0">
+                                    <rect key="frame" x="125" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="0"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="6Dv-22-Rtp"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2CL-l8-eOm" userLabel="Right Configurable">
+                                    <rect key="frame" x="250" y="0.0" width="125" height="112.5"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                    <state key="normal" title="!"/>
+                                    <connections>
+                                        <action selector="selectedButton:forEvent:" destination="-1" eventType="touchUpInside" id="0vi-dl-Qxk"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <constraints>
+                <constraint firstItem="OR4-Tw-dWL" firstAttribute="centerX" secondItem="isW-hz-UL3" secondAttribute="centerX" id="2RB-ye-Niw"/>
+                <constraint firstItem="SJL-La-7sS" firstAttribute="centerX" secondItem="YOG-7B-Gao" secondAttribute="centerX" id="3xK-2U-1Ek"/>
+                <constraint firstItem="OR4-Tw-dWL" firstAttribute="centerY" secondItem="isW-hz-UL3" secondAttribute="centerY" constant="30" id="4Gl-mf-iOs"/>
+                <constraint firstItem="buk-0a-3yU" firstAttribute="centerY" secondItem="icA-0s-sAx" secondAttribute="centerY" constant="30" id="5D8-8t-W9D"/>
+                <constraint firstItem="RvE-9O-2KZ" firstAttribute="centerX" secondItem="Rat-0b-8SN" secondAttribute="centerX" id="5bX-Mz-zkp"/>
+                <constraint firstItem="PrX-zz-twe" firstAttribute="centerY" secondItem="Yvz-3j-zCD" secondAttribute="centerY" constant="30" id="DfP-GU-GTy"/>
+                <constraint firstItem="CeK-WW-fye" firstAttribute="centerX" secondItem="h8H-VR-qrX" secondAttribute="centerX" id="Dl3-Be-vBI"/>
+                <constraint firstItem="Diy-VN-O4a" firstAttribute="trailing" secondItem="3Pm-9K-MUS" secondAttribute="trailing" id="Fqg-vz-Yag"/>
+                <constraint firstItem="mmm-rb-uRs" firstAttribute="centerY" secondItem="p90-mV-N7b" secondAttribute="centerY" constant="30" id="H7D-V6-Xfw"/>
+                <constraint firstItem="8qo-su-Et1" firstAttribute="centerX" secondItem="Kie-Da-7F1" secondAttribute="centerX" id="JqS-9X-SuL"/>
+                <constraint firstItem="RvE-9O-2KZ" firstAttribute="centerY" secondItem="Rat-0b-8SN" secondAttribute="centerY" constant="30" id="OdQ-FM-pi4"/>
+                <constraint firstItem="TXZ-BI-yjD" firstAttribute="centerY" secondItem="2CL-l8-eOm" secondAttribute="centerY" constant="30" id="RF1-PW-UPd"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="3Pm-9K-MUS" secondAttribute="trailing" id="So0-y3-p8m"/>
+                <constraint firstItem="VLA-zI-FYu" firstAttribute="centerY" secondItem="wKZ-fv-2Cr" secondAttribute="centerY" constant="30" id="W5b-GF-idq"/>
+                <constraint firstItem="1Ae-8W-gda" firstAttribute="centerX" secondItem="plD-sM-fHP" secondAttribute="centerX" id="hQB-jY-12U"/>
+                <constraint firstItem="Diy-VN-O4a" firstAttribute="top" secondItem="3Pm-9K-MUS" secondAttribute="top" id="hco-Ho-ibV"/>
+                <constraint firstItem="3Pm-9K-MUS" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="hdB-EZ-lVr"/>
+                <constraint firstItem="9Ad-Qx-B2z" firstAttribute="centerX" secondItem="TZi-ya-q8V" secondAttribute="centerX" id="hk8-gZ-B48"/>
+                <constraint firstItem="8qo-su-Et1" firstAttribute="centerY" secondItem="Kie-Da-7F1" secondAttribute="centerY" constant="30" id="ncL-Ka-ndw"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="3Pm-9K-MUS" secondAttribute="bottom" id="olU-lc-z0d"/>
+                <constraint firstItem="1Ae-8W-gda" firstAttribute="centerY" secondItem="plD-sM-fHP" secondAttribute="centerY" constant="30" id="oy3-zw-Wfp"/>
+                <constraint firstItem="mmm-rb-uRs" firstAttribute="centerX" secondItem="p90-mV-N7b" secondAttribute="centerX" id="pRM-l0-3cV"/>
+                <constraint firstItem="9Ad-Qx-B2z" firstAttribute="centerY" secondItem="TZi-ya-q8V" secondAttribute="centerY" constant="30" id="pb0-aZ-esB"/>
+                <constraint firstItem="TXZ-BI-yjD" firstAttribute="centerX" secondItem="2CL-l8-eOm" secondAttribute="centerX" id="ppa-nt-j9y"/>
+                <constraint firstItem="Diy-VN-O4a" firstAttribute="bottom" secondItem="3Pm-9K-MUS" secondAttribute="bottom" id="q3N-91-bBD"/>
+                <constraint firstItem="SJL-La-7sS" firstAttribute="centerY" secondItem="YOG-7B-Gao" secondAttribute="centerY" constant="30" id="qmh-fv-wZT"/>
+                <constraint firstItem="3Pm-9K-MUS" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="rBF-yM-XtU"/>
+                <constraint firstItem="VLA-zI-FYu" firstAttribute="centerX" secondItem="wKZ-fv-2Cr" secondAttribute="centerX" id="rSN-Hc-4yJ"/>
+                <constraint firstItem="PrX-zz-twe" firstAttribute="centerX" secondItem="Yvz-3j-zCD" secondAttribute="centerX" id="tde-BR-RiM"/>
+                <constraint firstItem="CeK-WW-fye" firstAttribute="centerY" secondItem="h8H-VR-qrX" secondAttribute="centerY" constant="30" id="x8h-rh-Jaw"/>
+                <constraint firstItem="Diy-VN-O4a" firstAttribute="leading" secondItem="3Pm-9K-MUS" secondAttribute="leading" id="ynd-QX-UFA"/>
+                <constraint firstItem="buk-0a-3yU" firstAttribute="centerX" secondItem="icA-0s-sAx" secondAttribute="centerX" id="z8n-1h-0sz"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
## Additional Commit Messages
* Removes "next" button from PinViewController
* Adds a reusable custom / configurable KeyboardView class
* Simplifies PinEntryViewController completion logic

## Screenshot
<img width="478" alt="screenshot 2018-05-25 00 17 54" src="https://user-images.githubusercontent.com/728690/40525938-42d872ea-5fb1-11e8-9588-056e27ed5f08.png">

## Bounty
Part 1 of #37 

## What does this change?
This PR creates a new, reusable `KeyboardView` that can be dropped in anywhere. 

It also replaces the `UITextField` on the `PinViewController`, with the new `KeyboardView`.