### PR TITLE
[FIX] Adds support to cancel pin entry on clearing wallet / viewing mnemonic

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		26BB0291965990A98D4BF0BB /* Pods_BlockEQTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89B1C324671F6269D8DB10A7 /* Pods_BlockEQTests.framework */; };
 		A6066F61786CC7405A06A52A /* Pods_BlockEQ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2BFC2D9DF7C32F6D40C804F /* Pods_BlockEQ.framework */; };
 		BCB2B19D8A0C42DDC9D826C1 /* Pods_BlockEQUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6912708A90B522F68A7AFA11 /* Pods_BlockEQUITests.framework */; };
+		C50F390220C0AE8100DABB14 /* KeyboardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50F390120C0AE8100DABB14 /* KeyboardHelper.swift */; };
 		C52186B920C06B8100FF2A76 /* PinOptionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52186B820C06B8100FF2A76 /* PinOptionHelper.swift */; };
 		C525C97920B79695006C138F /* KeyboardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = C525C97820B79695006C138F /* KeyboardView.xib */; };
 		C525C97B20B79890006C138F /* KeyboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C525C97A20B79890006C138F /* KeyboardView.swift */; };
@@ -135,6 +136,7 @@
 		6978359A021C7947F1C6AC48 /* Pods-BlockEQTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlockEQTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BlockEQTests/Pods-BlockEQTests.release.xcconfig"; sourceTree = "<group>"; };
 		89B1C324671F6269D8DB10A7 /* Pods_BlockEQTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BlockEQTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2BFC2D9DF7C32F6D40C804F /* Pods_BlockEQ.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BlockEQ.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C50F390120C0AE8100DABB14 /* KeyboardHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHelper.swift; sourceTree = "<group>"; };
 		C52186B820C06B8100FF2A76 /* PinOptionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinOptionHelper.swift; sourceTree = "<group>"; };
 		C525C97820B79695006C138F /* KeyboardView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = KeyboardView.xib; sourceTree = "<group>"; };
 		C525C97A20B79890006C138F /* KeyboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardView.swift; sourceTree = "<group>"; };
@@ -464,6 +466,7 @@
 				EC0B19252054BC3B0052802C /* AppNavigationController.swift */,
 				EC72C0B12059742900141D6F /* KeychainHelper.swift */,
 				C52186B820C06B8100FF2A76 /* PinOptionHelper.swift */,
+				C50F390120C0AE8100DABB14 /* KeyboardHelper.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -862,6 +865,7 @@
 				C5AB412F20902E4800096A29 /* SettingNode.swift in Sources */,
 				EC1CEE4F205774E70005F74E /* VerificationViewController.swift in Sources */,
 				EC72C0B22059742900141D6F /* KeychainHelper.swift in Sources */,
+				C50F390220C0AE8100DABB14 /* KeyboardHelper.swift in Sources */,
 				EC6EE88620B5C1320033C299 /* TradeSegmentViewController.swift in Sources */,
 				EC2015E22052E6B6009A73C8 /* UIColor+Gradient.swift in Sources */,
 				C525C97B20B79890006C138F /* KeyboardView.swift in Sources */,

--- a/BlockEQ/Coordinators/ApplicationCoordinator.swift
+++ b/BlockEQ/Coordinators/ApplicationCoordinator.swift
@@ -181,7 +181,7 @@ extension ApplicationCoordinator: SettingsDelegate {
         let pinViewController = PinViewController(mode: .dark,
                                                   pin: nil,
                                                   confirming: true,
-                                                  isCloseDisplayed: false,
+                                                  isCloseDisplayed: true,
                                                   shouldSavePin: false)
 
         pinViewController.delegate = self

--- a/BlockEQ/Utils/KeyboardHelper.swift
+++ b/BlockEQ/Utils/KeyboardHelper.swift
@@ -1,0 +1,41 @@
+//
+//  KeyboardHelper.swift
+//  BlockEQ
+//
+//  Created by Nick DiZazzo on 2018-05-31.
+//  Copyright © 2018 BlockEQ. All rights reserved.
+//
+
+import Foundation
+
+final class KeyboardHelper {
+    static let basicKeypadButtons = [
+        ("1", ""),
+        ("2", "ABC"),
+        ("3", "DEF"),
+        ("4", "GHI"),
+        ("5", "JKL"),
+        ("6", "MNO"),
+        ("7", "PQRS"),
+        ("8", "TUV"),
+        ("9", "WXYZ"),
+        ("", ""),
+        ("0", ""),
+        ("", "")
+    ]
+
+    static let cancelKeypadButtons = [
+        ("1", ""),
+        ("2", "ABC"),
+        ("3", "DEF"),
+        ("4", "GHI"),
+        ("5", "JKL"),
+        ("6", "MNO"),
+        ("7", "PQRS"),
+        ("8", "TUV"),
+        ("9", "WXYZ"),
+        ("CANCEL", ""),
+        ("0", ""),
+        ("", "")
+    ]
+}

--- a/BlockEQ/View Controllers/Wallet Creation and Restoration/PinViewController.swift
+++ b/BlockEQ/View Controllers/Wallet Creation and Restoration/PinViewController.swift
@@ -66,72 +66,29 @@ class PinViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         impactGenerator.prepare()
-    }
-
-    func setupView() {
-        keyboardView.delegate = self
 
         var pinDotColor: UIColor
         var pinLineColor: UIColor
         var keyboardTextColor: UIColor
 
         if self.mode == .dark {
-            pinViewHolder.backgroundColor = Colors.primaryDark
-            view.backgroundColor = Colors.primaryDark
             keyboardTextColor = .white
             pinLineColor = Colors.white
             pinDotColor = Colors.tertiaryDark
-            titleLabel.textColor = Colors.white
         } else {
-            pinViewHolder.backgroundColor = .white
-            view.backgroundColor = .white
             keyboardTextColor = Colors.primaryDark
             pinLineColor = Colors.darkGray
             pinDotColor = Colors.primaryDark
-            titleLabel.textColor = Colors.primaryDark
         }
 
+        let kbButtons = isCloseDisplayed ? KeyboardHelper.cancelKeypadButtons : KeyboardHelper.basicKeypadButtons
         keyboardView.update(with: KeyboardViewModel(options: KeyboardOptions.all,
-                                                    buttons: [
-                                                        ("1", ""),
-                                                        ("2", "ABC"),
-                                                        ("3", "DEF"),
-                                                        ("4", "GHI"),
-                                                        ("5", "JKL"),
-                                                        ("6", "MNO"),
-                                                        ("7", "PQRS"),
-                                                        ("8", "TUV"),
-                                                        ("9", "WXYZ"),
-                                                        ("", ""),
-                                                        ("0", ""),
-                                                        ("R", "")],
+                                                    buttons: kbButtons,
                                                     bottomLeftImage: nil,
                                                     bottomRightImage: UIImage(named: "backspace"),
                                                     labelColor: keyboardTextColor,
                                                     buttonColor: keyboardTextColor,
                                                     backgroundColor: .clear))
-
-        if isConfirming {
-            titleLabel.text = "PIN_ENTER_TITLE".localized()
-            title = "Confirm Pin"
-            navigationItem.title = "Confirm Pin"
-            navigationItem.setHidesBackButton(false, animated: false)
-        } else {
-            titleLabel.text = "PIN_CREATE_TITLE".localized()
-            title = "Create Pin"
-            navigationItem.title = "Create Pin"
-            navigationItem.setHidesBackButton(true, animated: false)
-        }
-
-        logoImageView.image = UIImage(named: "logoWhite")
-       
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
-        
-        if isCloseDisplayed {
-            let image = UIImage(named:"close")
-            let leftBarButtonItem = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(self.dismissView))
-            navigationItem.leftBarButtonItem = leftBarButtonItem
-        }
 
         pinViews = [pinView1, pinView2, pinView3, pinView4]
 
@@ -147,10 +104,44 @@ class PinViewController: UIViewController {
             pinView.reset()
         }
     }
+
+    func setupView() {
+        if self.mode == .dark {
+            pinViewHolder.backgroundColor = Colors.primaryDark
+            view.backgroundColor = Colors.primaryDark
+            titleLabel.textColor = Colors.white
+        } else {
+            pinViewHolder.backgroundColor = .white
+            view.backgroundColor = .white
+            titleLabel.textColor = Colors.primaryDark
+        }
+
+        if isConfirming {
+            titleLabel.text = "PIN_ENTER_TITLE".localized()
+            title = "Confirm Pin"
+            navigationItem.title = "Confirm Pin"
+            navigationItem.setHidesBackButton(false, animated: false)
+        } else {
+            titleLabel.text = "PIN_CREATE_TITLE".localized()
+            title = "Create Pin"
+            navigationItem.title = "Create Pin"
+            navigationItem.setHidesBackButton(true, animated: false)
+        }
+
+        logoImageView.image = UIImage(named: "logoWhite")
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        
+        if isCloseDisplayed {
+            let image = UIImage(named:"close")
+            let leftBarButtonItem = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(self.dismissView))
+            navigationItem.leftBarButtonItem = leftBarButtonItem
+        }
+
+        keyboardView.delegate = self
+    }
     
     @objc func dismissView() {
         view.endEditing(true)
-        
         dismiss(animated: true, completion: nil)
     }
     
@@ -182,7 +173,10 @@ extension PinViewController: KeyboardViewDelegate {
             guard pin.count > 0 else { return }
             let index = pin.index(pin.startIndex, offsetBy: pin.count-1)
             pin = String(pin[..<index])
-        default: print("???")
+        case .left where self.isCloseDisplayed == true:
+            self.dismiss(animated: true, completion: nil)
+        default:
+            print("Unhandled button")
         }
 
         for (index, pinView) in pinViews.enumerated() {

--- a/BlockEQ/Views/KeyboardView.swift
+++ b/BlockEQ/Views/KeyboardView.swift
@@ -27,14 +27,35 @@ struct KeyboardOptions: OptionSet {
 }
 
 struct KeyboardViewModel {
+    typealias KeyboardButton = (title: String, label: String)
     var options: KeyboardOptions
-    var buttons: [(title: String, label: String)]
+    var buttons: [KeyboardButton]
     var bottomLeftImage: UIImage?
     var bottomRightImage: UIImage?
 
     var labelColor: UIColor
     var buttonColor: UIColor
     var backgroundColor: UIColor
+
+    var keyFont = UIFont.systemFont(ofSize: 24, weight: .medium)
+    var leftFont = UIFont.systemFont(ofSize: 14, weight: .medium)
+    var rightFont = UIFont.systemFont(ofSize: 14, weight: .medium)
+
+    init(options: KeyboardOptions,
+         buttons: [KeyboardButton],
+         bottomLeftImage: UIImage?,
+         bottomRightImage: UIImage?,
+         labelColor: UIColor,
+         buttonColor: UIColor,
+         backgroundColor: UIColor) {
+        self.options = options
+        self.buttons = buttons
+        self.bottomLeftImage = bottomLeftImage
+        self.bottomRightImage = bottomRightImage
+        self.labelColor = labelColor
+        self.buttonColor = buttonColor
+        self.backgroundColor = backgroundColor
+    }
 }
 
 class KeyboardView: UIView {
@@ -126,6 +147,7 @@ class KeyboardView: UIView {
         for button in keyButtons.enumerated() {
             keyButtons[button.offset].setTitle(viewModel.buttons[button.offset].title, for: .normal)
             keyButtons[button.offset].setTitleColor(viewModel.buttonColor, for: .normal)
+            keyButtons[button.offset].titleLabel?.font = viewModel.keyFont
         }
 
         let leftHidden = !viewModel.options.contains(.leftButton)
@@ -133,12 +155,14 @@ class KeyboardView: UIView {
         leftConfigurableLabel.isHidden = leftHidden
         leftConfigurableButton.setImage(viewModel.bottomLeftImage, for: .normal)
         leftConfigurableButton.tintColor = viewModel.buttonColor
+        leftConfigurableButton.titleLabel?.font = viewModel.leftFont
 
         let rightHidden = !viewModel.options.contains(.rightButton)
         rightConfigurableButton.isHidden = rightHidden
         rightConfigurableLabel.isHidden = rightHidden
         rightConfigurableButton.setImage(viewModel.bottomRightImage, for: .normal)
         rightConfigurableButton.tintColor = viewModel.buttonColor
+        rightConfigurableButton.titleLabel?.font = viewModel.rightFont
 
         if viewModel.bottomLeftImage != nil {
             leftConfigurableButton.setTitle(nil, for: .normal)


### PR DESCRIPTION
## Priority
Normal

## Screenshot
<img width="516" alt="screenshot 2018-05-31 21 05 27" src="https://user-images.githubusercontent.com/728690/40815774-cdc8ce58-6516-11e8-8c09-fe9d432bdac5.png">

## What does this change?
This allows the user to cancel the "clear wallet" if they change their mind when entering their PIN. Same for viewing the mnemonic.