### PR TITLE
[FIX] Corrects issue when disabling PIN requirement and cancelling PIN entry

### DIFF
--- a/BlockEQ/AppDelegate.swift
+++ b/BlockEQ/AppDelegate.swift
@@ -95,6 +95,10 @@ extension AppDelegate: OnboardingCoordinatorDelegate {
 }
 
 extension AppDelegate: PinViewControllerDelegate {
+    func pinEntryCancelled(_ vc: PinViewController) {
+        vc.dismiss(animated: true, completion: nil)
+    }
+
     func pinEntryCompleted(_ vc: PinViewController, pin: String, save: Bool) {
         if KeychainHelper.checkPin(inPin: pin) {
             vc.dismiss(animated: true, completion: nil)

--- a/BlockEQ/Coordinators/OnboardingCoordinator.swift
+++ b/BlockEQ/Coordinators/OnboardingCoordinator.swift
@@ -68,6 +68,10 @@ extension OnboardingCoordinator: VerificationViewControllerDelegate {
 }
 
 extension OnboardingCoordinator: PinViewControllerDelegate {
+    func pinEntryCancelled(_ vc: PinViewController) {
+        assert(false, "You shouldn't be able to dismiss the PIN entry during onboarding. Fix this!")
+    }
+
     func pinEntryCompleted(_ vc: PinViewController, pin: String, save: Bool) {
         if firstPin == nil {
             firstPin = pin

--- a/BlockEQ/View Controllers/SendAmountViewController.swift
+++ b/BlockEQ/View Controllers/SendAmountViewController.swift
@@ -205,6 +205,10 @@ extension SendAmountViewController: UITextFieldDelegate {
 }
 
 extension SendAmountViewController: PinViewControllerDelegate {
+    func pinEntryCancelled(_ vc: PinViewController) {
+        vc.dismiss(animated: true, completion: nil)
+    }
+
     func pinEntryCompleted(_ vc: PinViewController, pin: String, save: Bool) {
         guard let amount = amountLabel.text, !amount.isEmpty, amount != "0" else {
             return

--- a/BlockEQ/View Controllers/Wallet Creation and Restoration/PinViewController.swift
+++ b/BlockEQ/View Controllers/Wallet Creation and Restoration/PinViewController.swift
@@ -11,6 +11,7 @@ import Foundation
 
 protocol PinViewControllerDelegate: class {
     func pinEntryCompleted(_ vc: PinViewController, pin: String, save: Bool)
+    func pinEntryCancelled(_ vc: PinViewController)
 }
 
 class PinViewController: UIViewController {
@@ -174,7 +175,7 @@ extension PinViewController: KeyboardViewDelegate {
             let index = pin.index(pin.startIndex, offsetBy: pin.count-1)
             pin = String(pin[..<index])
         case .left where self.isCloseDisplayed == true:
-            self.dismiss(animated: true, completion: nil)
+            delegate?.pinEntryCancelled(self)
         default:
             print("Unhandled button")
         }

--- a/BlockEQ/View Controllers/WalletViewController.swift
+++ b/BlockEQ/View Controllers/WalletViewController.swift
@@ -223,6 +223,10 @@ extension WalletViewController: UIScrollViewDelegate {
 }
 
 extension WalletViewController: PinViewControllerDelegate {
+    func pinEntryCancelled(_ vc: PinViewController) {
+        vc.dismiss(animated: true, completion: nil)
+    }
+
     func pinEntryCompleted(_ vc: PinViewController, pin: String, save: Bool) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             if self.isShowingSeed {


### PR DESCRIPTION
## Priority
Normal

## Screenshot
N/A

## What does this change?
This allows the user to cancel the "Require PIN" challenge, and restore the prior setting if it does get cancelled.

## Steps to Test
1. Create a wallet and set a PIN
2. Go to the settings menu and select "Require PIN" to disable PIN entry
3. The keyboard should pop up
4. Hit "cancel" (bottom left)
5. The "Require PIN" option should **still be enabled**
6. The app should still prompt for PINs when opening / trading / viewing mnemonic, etc.