### PR TITLE
[FIX] Quick fix when a network request fails, and assets.count is zero

### DIFF
--- a/BlockEQ/View Controllers/WalletViewController.swift
+++ b/BlockEQ/View Controllers/WalletViewController.swift
@@ -280,7 +280,17 @@ extension WalletViewController {
         guard let accountId = KeychainHelper.getAccountId() else {
             return
         }
-        
+
+        guard self.accounts.count > 0 else {
+            return
+        }
+
+        let account = self.accounts[pageControl.currentPage]
+
+        guard account.assets.count > 0 else {
+            return
+        }
+
         let stellarAsset = self.accounts[pageControl.currentPage].assets[currentAssetIndex]
         
         PaymentTransactionOperation.getTransactions(accountId: accountId, stellarAsset: stellarAsset) { transactions in


### PR DESCRIPTION
## Priority 
Normal

## Screenshot
N/A

## Description
This fix corrects an array index crash that can occur when a query to the Stellar network could fail to populate assets in the wallet.