### PR TITLE
[FIX] Corrects asset catalog use in project file

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -1042,6 +1042,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 624B50722A9FCCC360CC73E3 /* Pods-BlockEQ.debug.xcconfig */;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1065,6 +1066,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EA487049D94C0F37E5791674 /* Pods-BlockEQ.release.xcconfig */;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: The Working Group Inc";

--- a/BlockEQ.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/BlockEQ.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/BlockEQ/Info.plist
+++ b/BlockEQ/Info.plist
@@ -8,6 +8,10 @@
 	<string>Block EQ</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIcons</key>
+	<dict/>
+	<key>CFBundleIcons~ipad</key>
+	<dict/>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
## Priority 
Normal

## Screenshot
<img width="899" alt="screenshot 2018-06-04 19 02 48" src="https://user-images.githubusercontent.com/728690/40950969-e2acb6d4-6829-11e8-897a-546f6a5f5a61.png">

## Description
Re-adds the mistakenly removed project file entry for AppIcon asset catalog.

**NOTE:** It looks red in the screenshot above, but works when deployed to a device.