### PR TITLE
[FEATURE] Hides the "Remove Asset" button when balance is above 0

### DIFF
--- a/BlockEQ/Objects/StellarAsset.swift
+++ b/BlockEQ/Objects/StellarAsset.swift
@@ -33,12 +33,29 @@ class StellarAsset: NSObject {
     var shortCode: String {
         if assetType == AssetTypeAsString.NATIVE {
             return "XLM"
-        } else {
-            if let code = assetCode {
-                return code
-            }
-            return ""
         }
+
+        if let code = assetCode {
+            return code
+        }
+
+        return ""
+    }
+
+    var isNative: Bool {
+        if assetType == AssetTypeAsString.NATIVE {
+            return true
+        }
+
+        return false
+    }
+
+    var hasZeroBalance: Bool {
+        if let balance = Double(balance) {
+            return balance.isZero
+        }
+
+        return true
     }
 
     static func == (lhs: StellarAsset, rhs: StellarAsset) -> Bool {

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -118,3 +118,7 @@
 "APPINFO_FORMAT" = "@\nVersion: %@ (%@)";
 "BLOCKEQ_WEBSITE" = "BlockEQ Website";
 "COPY" = "Copy";
+
+"REMOVE_ASSET" = "Remove Asset";
+"SET_INFLATION" = "Set Inflation";
+"UPDATE_INFLATION" = "Update Inflation";

--- a/BlockEQ/View Controllers/Menus/WalletSwitchingViewController.swift
+++ b/BlockEQ/View Controllers/Menus/WalletSwitchingViewController.swift
@@ -205,35 +205,27 @@ extension WalletSwitchingViewController: UITableViewDataSource {
         case SectionType.userAssets.rawValue:
             let item = allAssets[indexPath.row]
             let walletCell: WalletItemCell = tableView.dequeueReusableCell(for: indexPath)
+            var viewModel = WalletItemCell.ViewModel(title: Assets.displayTitle(shortCode: item.shortCode),
+                                                     amount: "\(item.formattedBalance) \(item.shortCode)")
 
             walletCell.indexPath = indexPath
             walletCell.delegate = self
-            walletCell.titleLabel.text = Assets.displayTitle(shortCode: item.shortCode)
-            walletCell.amountLabel.text = "\(item.formattedBalance) \(item.shortCode)"
-            walletCell.iconImageView.backgroundColor = Assets.displayImageBackgroundColor(shortCode: item.shortCode)
+
             if let image = Assets.displayImage(shortCode: item.shortCode) {
-                walletCell.iconImageView.image = image
-                walletCell.tokenInitialLabel.text = ""
+                viewModel.icon = image
             } else {
-                walletCell.iconImageView.image = nil
                 let shortcode = Assets.displayTitle(shortCode: item.shortCode)
-                walletCell.tokenInitialLabel.text = String(Array(shortcode)[0])
+                viewModel.tokenText = String(Array(shortcode)[0])
+                viewModel.iconBackground = Assets.displayImageBackgroundColor(shortCode: item.shortCode)
             }
 
-            if item.shortCode == "XLM" {
-                walletCell.removeAssetButton.isHidden = true
-                if stellarAccount.inflationDestination != nil {
-                    walletCell.setInflationButton.isHidden = true
-                    walletCell.updateInflationButton.isHidden = false
-                } else {
-                    walletCell.setInflationButton.isHidden = false
-                    walletCell.updateInflationButton.isHidden = true
-                }
+            if item.isNative {
+                viewModel.mode = stellarAccount.inflationDestination != nil ? .updateInflation : .setInflation
             } else {
-                walletCell.removeAssetButton.isHidden = false
-                walletCell.setInflationButton.isHidden = true
-                walletCell.updateInflationButton.isHidden = true
+                viewModel.mode = item.hasZeroBalance ? .removeAsset : .none
             }
+
+            walletCell.update(with: viewModel)
 
             return walletCell
         default:
@@ -241,12 +233,14 @@ extension WalletSwitchingViewController: UITableViewDataSource {
             let displayString = String(format: "%@ %@", Assets.displayTitle(shortCode: shortCode), shortCode)
 
             let walletCell: WalletItemActivateCell = tableView.dequeueReusableCell(for: indexPath)
-
+            var viewModel = WalletItemActivateCell.ViewModel(title: displayString)
             walletCell.indexPath = indexPath
             walletCell.delegate = self
-            walletCell.titleLabel.text = displayString
-            walletCell.iconImageView.backgroundColor = Assets.displayImageBackgroundColor(shortCode: shortCode)
-            walletCell.iconImageView.image = Assets.displayImage(shortCode: shortCode)
+
+            viewModel.iconBackground = Assets.displayImageBackgroundColor(shortCode: shortCode)
+            viewModel.icon = Assets.displayImage(shortCode: shortCode)
+
+            walletCell.update(with: viewModel)
 
             return walletCell
         }

--- a/BlockEQ/Views/Cells/WalletItemActivateCell.swift
+++ b/BlockEQ/Views/Cells/WalletItemActivateCell.swift
@@ -13,6 +13,15 @@ protocol WalletItemActivateCellDelegate: class {
 }
 
 class WalletItemActivateCell: UITableViewCell, ReusableView {
+    struct ViewModel {
+        var title: String
+        var icon: UIImage?
+        var iconBackground: UIColor?
+
+        init(title: String) {
+            self.title = title
+        }
+    }
 
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var iconImageView: UIImageView!
@@ -30,7 +39,6 @@ class WalletItemActivateCell: UITableViewCell, ReusableView {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-
         setupView()
     }
 
@@ -39,15 +47,19 @@ class WalletItemActivateCell: UITableViewCell, ReusableView {
         titleLabel.textColor = Colors.white
     }
 
+    func update(with viewModel: ViewModel) {
+        self.titleLabel.text = viewModel.title
+        self.iconImageView.image = viewModel.icon
+        self.iconImageView.backgroundColor = viewModel.iconBackground
+    }
+
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
         setRowColor(selected: selected)
     }
 
     override func setHighlighted(_ highlighted: Bool, animated: Bool) {
         super.setHighlighted(highlighted, animated: animated)
-
         setRowColor(selected: highlighted)
     }
 

--- a/BlockEQ/Views/Cells/WalletItemCell.swift
+++ b/BlockEQ/Views/Cells/WalletItemCell.swift
@@ -14,6 +14,27 @@ protocol WalletItemCellDelegate: class {
 }
 
 class WalletItemCell: UITableViewCell, ReusableView {
+    enum ButtonMode {
+        case none
+        case removeAsset
+        case updateInflation
+        case setInflation
+    }
+
+    struct ViewModel {
+        var title: String
+        var amount: String
+        var tokenText: String?
+        var icon: UIImage?
+        var iconBackground: UIColor?
+        var mode: ButtonMode = .none
+
+        init(title: String, amount: String) {
+            self.title = title
+            self.amount = amount
+        }
+    }
+
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var amountLabel: UILabel!
     @IBOutlet var tokenInitialLabel: UILabel!
@@ -46,18 +67,39 @@ class WalletItemCell: UITableViewCell, ReusableView {
         removeAssetButton.backgroundColor = Colors.red
         setInflationButton.backgroundColor = Colors.green
         updateInflationButton.backgroundColor = Colors.secondaryDark
+
+        removeAssetButton.setTitle("REMOVE_ASSET".localized(), for: .normal)
+        setInflationButton.setTitle("SET_INFLATION".localized(), for: .normal)
+        updateInflationButton.setTitle("UPDATE_INFLATION".localized(), for: .normal)
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
         setRowColor(selected: selected)
     }
 
     override func setHighlighted(_ highlighted: Bool, animated: Bool) {
         super.setHighlighted(highlighted, animated: animated)
-
         setRowColor(selected: highlighted)
+    }
+
+    func update(with viewModel: ViewModel) {
+        self.titleLabel.text = viewModel.title
+        self.amountLabel.text = viewModel.amount
+        self.iconImageView.image = viewModel.icon ?? nil
+        self.iconImageView.backgroundColor = viewModel.iconBackground ?? UIColor.clear
+        self.tokenInitialLabel.text = viewModel.tokenText ?? ""
+
+        self.removeAssetButton.isHidden = true
+        self.setInflationButton.isHidden = true
+        self.updateInflationButton.isHidden = true
+
+        switch viewModel.mode {
+        case .none: break
+        case .removeAsset: self.removeAssetButton.isHidden = false
+        case .setInflation: self.setInflationButton.isHidden = false
+        case .updateInflation: self.updateInflationButton.isHidden = false
+        }
     }
 
     func setRowColor(selected: Bool) {


### PR DESCRIPTION
## Priority
Normal

## Description
This PR addresses the user experience of the assets currently managed by the wallet, by not allowing the user to remove the asset if the balance is greater than zero.

This prevents the user from encountering a confusing error prompt.

## Notes
This refactors the `WalletItemCell`, and `WalletItemActivateCell` class to use a `ViewModel` pattern to help move towards being able to eventually snapshot test our cells.

## Screenshot
![img_f09f559a0fd0-1](https://user-images.githubusercontent.com/728690/46303377-a5e89d00-c579-11e8-9110-4805b2e59fb5.jpeg)