### PR TITLE
[FIX] Corrects the ability to enter invalid trade amounts

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		C5AB413B2090433000096A29 /* UIView+ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AB413A2090433000096A29 /* UIView+ReusableView.swift */; };
 		C5AB413D2090436700096A29 /* UIView+NibLoadableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AB413C2090436700096A29 /* UIView+NibLoadableView.swift */; };
 		C5AF7C8A2094B60A00F99835 /* UIImage+CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AF7C892094B60A00F99835 /* UIImage+CALayer.swift */; };
+		C5BED37C2163F1E100BEE464 /* Price+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BED37B2163F1E100BEE464 /* Price+Extensions.swift */; };
 		C5BED3762162A81C00BEE464 /* Exchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BED3752162A81C00BEE464 /* Exchange.swift */; };
 		C5BED3782162B9E700BEE464 /* exchanges.json in Resources */ = {isa = PBXBuildFile; fileRef = C5BED3772162B9E700BEE464 /* exchanges.json */; };
 		C5C1D3D6211BF39B0014B39F /* UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C1D3D5211BF39B0014B39F /* UIDevice.swift */; };
@@ -235,6 +236,7 @@
 		C5AB413A2090433000096A29 /* UIView+ReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ReusableView.swift"; sourceTree = "<group>"; };
 		C5AB413C2090436700096A29 /* UIView+NibLoadableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+NibLoadableView.swift"; sourceTree = "<group>"; };
 		C5AF7C892094B60A00F99835 /* UIImage+CALayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+CALayer.swift"; sourceTree = "<group>"; };
+		C5BED37B2163F1E100BEE464 /* Price+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Price+Extensions.swift"; sourceTree = "<group>"; };
 		C5BED3752162A81C00BEE464 /* Exchange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exchange.swift; sourceTree = "<group>"; };
 		C5BED37A2162DBC600BEE464 /* BlockEQ.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BlockEQ.entitlements; sourceTree = "<group>"; };
 		C5BED3772162B9E700BEE464 /* exchanges.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = exchanges.json; sourceTree = "<group>"; };
@@ -644,6 +646,7 @@
 				C5C1D3D5211BF39B0014B39F /* UIDevice.swift */,
 				C5A5A879215E91F500007787 /* UIView+Autolayout.swift */,
 				C5A5A87B215E935C00007787 /* UIAlertController+Prompts.swift */,
+				C5BED37B2163F1E100BEE464 /* Price+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1068,6 +1071,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C4167B9221234E6C00F44136 /* SecurityOptionHelper.swift in Sources */,
+				C5BED37C2163F1E100BEE464 /* Price+Extensions.swift in Sources */,
 				EC4F660020C8CF0C0036293D /* String+Date.swift in Sources */,
 				EC4BB64720BE2C28008252AD /* TradeOperation.swift in Sources */,
 				C5BED3762162A81C00BEE464 /* Exchange.swift in Sources */,

--- a/BlockEQ/Extensions/Price+Extensions.swift
+++ b/BlockEQ/Extensions/Price+Extensions.swift
@@ -1,0 +1,36 @@
+//
+//  Price+Extensions.swift
+//  BlockEQ
+//
+//  Created by Nick DiZazzo on 2018-10-02.
+//  Copyright © 2018 BlockEQ. All rights reserved.
+//
+
+import stellarsdk
+
+extension Price {
+    enum Error: LocalizedError {
+        case amountOverflow
+    }
+
+    convenience init(numerator: Double, denominator: Double) throws {
+        let doubleMaxInt = Double(Int.max)
+        guard numerator <= doubleMaxInt && denominator <= doubleMaxInt else {
+            throw Price.Error.amountOverflow
+        }
+
+        let intNumerator = NSDecimalNumber(value: numerator).intValue
+        let intDenominator = NSDecimalNumber(value: denominator).intValue
+        self.init(numerator: intNumerator, denominator: intDenominator)
+    }
+
+    convenience init(numerator: Decimal, denominator: Decimal) {
+        let intNumerator = NSDecimalNumber(decimal: numerator).intValue
+        let intDenominator = NSDecimalNumber(decimal: denominator).intValue
+        self.init(numerator: intNumerator, denominator: intDenominator)
+    }
+
+    convenience init(with response: OfferPriceResponse) {
+        self.init(numerator: response.numerator, denominator: response.denominator)
+    }
+}

--- a/BlockEQ/Operations/TradeOperation.swift
+++ b/BlockEQ/Operations/TradeOperation.swift
@@ -61,8 +61,8 @@ class TradeOperation: NSObject {
     }
 
     static func postTrade(amount: Decimal,
-                          price: (numerator: Int, denominator: Int),
-                          asset: (selling: StellarAsset, buying: StellarAsset),
+                          price: Price,
+                          assets: (selling: StellarAsset, buying: StellarAsset),
                           offerId: Int,
                           completion: @escaping (Bool) -> Void) {
         guard let sourceKeyPair = KeychainHelper.walletKeyPair else {
@@ -74,15 +74,14 @@ class TradeOperation: NSObject {
             switch response {
             case .success(let accountResponse):
                 do {
-                    let buyAsset = self.getAsset(stellarAsset: asset.buying)
-                    let sellAsset = self.getAsset(stellarAsset: asset.selling)
-                    let priceObject = Price(numerator: price.numerator, denominator: price.denominator)
+                    let buyAsset = self.getAsset(stellarAsset: assets.buying)
+                    let sellAsset = self.getAsset(stellarAsset: assets.selling)
 
                     let manageOfferOperation = ManageOfferOperation(sourceAccount: sourceKeyPair,
                                                                     selling: sellAsset,
                                                                     buying: buyAsset,
                                                                     amount: amount,
-                                                                    price: priceObject,
+                                                                    price: price,
                                                                     offerId: UInt64(offerId))
 
                     let transaction = try Transaction(sourceAccount: accountResponse,

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -61,7 +61,8 @@
 
 "TRADE_MARKET_INFO" = "Your market order may not be completely filled depending on amount offered. View the order book to see the amount available at the market rate. Any amount larger than this will be posted as an offer.";
 "TRADE_ERROR_TITLE" = "Trade Error";
-"TRADE_ERROR_MESSAGE" = "Sorry your order could not be processed at this time. Please try again later.";
+"TRADE_ERROR_MESSAGE" = "Your order could not be processed at this time. Please try again later.";
+"TRADE_INVALID_MESSAGE" = "The amounts entered for trade cannot be submitted. Please correct them and try again.";
 "GENERIC_OK_TEXT" = "Ok";
 
 "ACTIVATION_ERROR_TITLE" = "Activation Error";

--- a/BlockEQ/View Controllers/Trade/MyOffersViewController.swift
+++ b/BlockEQ/View Controllers/Trade/MyOffersViewController.swift
@@ -51,8 +51,8 @@ class MyOffersViewController: UIViewController {
                                        balance: "")
 
         TradeOperation.postTrade(amount: 0.0000000,
-                                 price: (numerator: offer.priceR.numerator, denominator: offer.priceR.denominator),
-                                 asset: (selling: sellingAsset, buying: buyingAsset),
+                                 price: Price(with: offer.priceR),
+                                 assets: (selling: sellingAsset, buying: buyingAsset),
                                  offerId: offer.id) { completed in
             if completed {
                 self.offers.remove(at: indexPath.row)


### PR DESCRIPTION
## Priority
Normal

## Description
This PR corrects behaviour when inputting large amounts into the trade fields.

It refactors the `TradeOperation` to directly accept a Stellar `Price` object, which simplifies logic inside the operation.

In addition to updating the `TradeOperation`, I've added an extension `Price+Extensions.swift` to the `Price` object to manage conversion and overflow checking, that is possible as a result of the issue here: https://github.com/Soneso/stellar-ios-mac-sdk/pull/32.

## Screenshot
N/A