### PR TITLE
[FIX] Updates TradeViewController to display available asset balance for XLM

### DIFF
--- a/BlockEQ/Extensions/String+DecimalFormatter.swift
+++ b/BlockEQ/Extensions/String+DecimalFormatter.swift
@@ -8,15 +8,40 @@
 
 import UIKit
 
+extension Formatter {
+    static let stringFormatters: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.generatesDecimalNumbers = true
+        formatter.maximumFractionDigits = 4
+        formatter.minimumFractionDigits = 2
+        formatter.groupingSeparator = ""
+        return formatter
+    }()
+}
+
 extension String {
-    func decimalFormatted() -> String {
-        return String(format: "%.4f", self.floatValue())
+    var decimalFormatted: String {
+        return Formatter.stringFormatters.string(for: self.doubleValue) ?? ""
     }
 
-    func floatValue() -> Float {
-        guard let floatValue = Float(self) else {
+    var doubleValue: Double {
+        guard let double = Double(self) else {
             return 0.00
         }
-        return floatValue
+
+        return double
+    }
+}
+
+extension Decimal {
+    var formattedString: String {
+        return Formatter.stringFormatters.string(for: self) ?? ""
+    }
+}
+
+extension Double {
+    var formattedString: String {
+        return Formatter.stringFormatters.string(for: self) ?? ""
     }
 }

--- a/BlockEQ/Objects/StellarAsset.swift
+++ b/BlockEQ/Objects/StellarAsset.swift
@@ -23,11 +23,7 @@ class StellarAsset: NSObject {
     }
 
     var formattedBalance: String {
-        guard let floatValue = Float(balance) else {
-            return ""
-        }
-
-        return String(format: "%.4f", floatValue)
+        return balance.decimalFormatted
     }
 
     var shortCode: String {

--- a/BlockEQ/Objects/StellarEffect.swift
+++ b/BlockEQ/Objects/StellarEffect.swift
@@ -142,11 +142,11 @@ class StellarEffect: NSObject {
     }
 
     func getFormatted(amountValue: String) -> String {
-        guard let floatValue = Float(amountValue) else {
+        guard let doubleValue = Double(amountValue) else {
             return "--"
         }
 
-        return String(format: "%.4f", floatValue)
+        return doubleValue.formattedString
     }
 
     func formattedTransactionAmount(asset: StellarAsset) -> String {

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -123,3 +123,6 @@
 "REMOVE_ASSET" = "Remove Asset";
 "SET_INFLATION" = "Set Inflation";
 "UPDATE_INFLATION" = "Update Inflation";
+
+"TRADE_BALANCE_FORMAT" = "%@ %@";
+"TRADE_BALANCE_AVAILABLE_FORMAT" = "%@ %@ available";

--- a/BlockEQ/View Controllers/Trade/MyOffersViewController.swift
+++ b/BlockEQ/View Controllers/Trade/MyOffersViewController.swift
@@ -92,11 +92,11 @@ extension MyOffersViewController: UITableViewDataSource {
         let offer = offers[indexPath.row]
 
         let text = String(format: "SELL_SUMMARY_FORMAT".localized(),
-                          offer.amount.decimalFormatted(),
+                          offer.amount.decimalFormatted,
                           Assets.cellDisplay(shortCode: offer.selling.assetCode),
-                          String(Float(offer.amount)! * Float(offer.price)!).decimalFormatted(),
+                          String(Double(offer.amount)! * Double(offer.price)!).decimalFormatted,
                           Assets.cellDisplay(shortCode: offer.buying.assetCode),
-                          offer.price.decimalFormatted())
+                          offer.price.decimalFormatted)
 
         cell.offerLabel.text = text
 

--- a/BlockEQ/View Controllers/Trade/OrderBookViewController.swift
+++ b/BlockEQ/View Controllers/Trade/OrderBookViewController.swift
@@ -115,13 +115,13 @@ extension OrderBookViewController: UITableViewDataSource {
     func bidOrderBookCell(indexPath: IndexPath) -> OrderBookCell {
         let cell: OrderBookCell = tableView.dequeueReusableCell(for: indexPath)
 
-        let numerator = Float(bids[indexPath.row].priceR.numerator)
-        let denominator = Float(bids[indexPath.row].priceR.denominator)
-        let result = denominator/numerator * bids[indexPath.row].amount.floatValue()
+        let numerator = Double(bids[indexPath.row].priceR.numerator)
+        let denominator = Double(bids[indexPath.row].priceR.denominator)
+        let result = denominator / numerator * bids[indexPath.row].amount.doubleValue
 
-        cell.option1Label.text = bids[indexPath.row].price.decimalFormatted()
-        cell.option2Label.text = String(result).decimalFormatted()
-        cell.option3Label.text = bids[indexPath.row].amount.decimalFormatted()
+        cell.option1Label.text = bids[indexPath.row].price.decimalFormatted
+        cell.option2Label.text = String(result).decimalFormatted
+        cell.option3Label.text = bids[indexPath.row].amount.decimalFormatted
 
         return cell
     }
@@ -129,10 +129,10 @@ extension OrderBookViewController: UITableViewDataSource {
     func askOrderBookCell(indexPath: IndexPath) -> OrderBookCell {
         let cell: OrderBookCell = tableView.dequeueReusableCell(for: indexPath)
 
-        let result = Float(asks[indexPath.row].price)! * Float(asks[indexPath.row].amount)!
-        cell.option1Label.text = asks[indexPath.row].price.decimalFormatted()
-        cell.option2Label.text = asks[indexPath.row].amount.decimalFormatted()
-        cell.option3Label.text = String(result).decimalFormatted()
+        let result = Double(asks[indexPath.row].price)! * Double(asks[indexPath.row].amount)!
+        cell.option1Label.text = asks[indexPath.row].price.decimalFormatted
+        cell.option2Label.text = asks[indexPath.row].amount.decimalFormatted
+        cell.option3Label.text = String(result).decimalFormatted
 
         return cell
     }

--- a/BlockEQ/View Controllers/WalletViewController.swift
+++ b/BlockEQ/View Controllers/WalletViewController.swift
@@ -265,7 +265,7 @@ extension WalletViewController {
             }
 
             self.availableBalanceLabel.text = "Available:  \(self.accounts[0].formattedAvailableBalance) XLM"
-            self.balanceLabel.text = asset.balance.decimalFormatted()
+            self.balanceLabel.text = asset.balance.decimalFormatted
             self.getEffects()
         }
     }


### PR DESCRIPTION
## Priority
Normal

## Description
This PR updates the `TradeViewController` to read the available balance if the from trade asset is native.

It also removes usage of `Float` for currency conversion, preferring `Double`. It also uses the new `NumberFormatter` class to specify exact formatting rules (which will be helpful for localization later)

## Screenshot
![1](https://user-images.githubusercontent.com/728690/46381018-8a14f200-c672-11e8-92ba-e00a752f24f2.gif)

## Notes
Addresses #78 

## Additional Commit Messages
* Codifies rounding rules with new NumberFormatter