### PR TITLE
Updates plist to support not entering export compliance in AppStore Connect

### DIFF
--- a/BlockEQ/Resources/Info.plist
+++ b/BlockEQ/Resources/Info.plist
@@ -51,5 +51,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
## Priority
Low

## Description
Enters a plist entry so we don't have to repetitively indicate export compliance settings.

## Screenshot
N/A

## Notes
N/A
