### PR TITLE
[FIX] Corrects decimal truncation of trade offers

### DIFF
--- a/BlockEQ/Extensions/Price+Extensions.swift
+++ b/BlockEQ/Extensions/Price+Extensions.swift
@@ -19,15 +19,21 @@ extension Price {
             throw Price.Error.amountOverflow
         }
 
-        let intNumerator = NSDecimalNumber(value: numerator).intValue
-        let intDenominator = NSDecimalNumber(value: denominator).intValue
-        self.init(numerator: intNumerator, denominator: intDenominator)
+        let int32Numerator = NSDecimalNumber(value: numerator).int32Value
+        let int32Denominator = NSDecimalNumber(value: denominator).int32Value
+        self.init(numerator: int32Numerator, denominator: int32Denominator)
     }
 
     convenience init(numerator: Decimal, denominator: Decimal) {
-        let intNumerator = NSDecimalNumber(decimal: numerator).intValue
-        let intDenominator = NSDecimalNumber(decimal: denominator).intValue
-        self.init(numerator: intNumerator, denominator: intDenominator)
+        let int32Numerator = NSDecimalNumber(decimal: numerator).int32Value
+        let int32Denominator = NSDecimalNumber(decimal: denominator).int32Value
+        self.init(numerator: int32Numerator, denominator: int32Denominator)
+    }
+
+    convenience init(numerator: Int, denominator: Int) {
+        let int32Numerator = NSDecimalNumber(value: numerator).int32Value
+        let int32Denominator = NSDecimalNumber(value: denominator).int32Value
+        self.init(numerator: int32Numerator, denominator: int32Denominator)
     }
 
     convenience init(with response: OfferPriceResponse) {

--- a/BlockEQ/Extensions/String+DecimalFormatter.swift
+++ b/BlockEQ/Extensions/String+DecimalFormatter.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension Formatter {
-    static let stringFormatters: NumberFormatter = {
+    static let displayFormatters: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.generatesDecimalNumbers = true
@@ -22,7 +22,7 @@ extension Formatter {
 
 extension String {
     var decimalFormatted: String {
-        return Formatter.stringFormatters.string(for: self.doubleValue) ?? ""
+        return Formatter.displayFormatters.string(for: self.doubleValue) ?? ""
     }
 
     var doubleValue: Double {
@@ -35,13 +35,13 @@ extension String {
 }
 
 extension Decimal {
-    var formattedString: String {
-        return Formatter.stringFormatters.string(for: self) ?? ""
+    var displayFormattedString: String {
+        return Formatter.displayFormatters.string(for: self) ?? ""
     }
 }
 
 extension Double {
-    var formattedString: String {
-        return Formatter.stringFormatters.string(for: self) ?? ""
+    var displayFormattedString: String {
+        return Formatter.displayFormatters.string(for: self) ?? ""
     }
 }

--- a/BlockEQ/Objects/StellarEffect.swift
+++ b/BlockEQ/Objects/StellarEffect.swift
@@ -146,7 +146,7 @@ class StellarEffect: NSObject {
             return "--"
         }
 
-        return doubleValue.formattedString
+        return doubleValue.displayFormattedString
     }
 
     func formattedTransactionAmount(asset: StellarAsset) -> String {

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -148,3 +148,7 @@
 "SEED_STORED" = "Your secret seed was stored securely in the AutoFill keychain.";
 "SAVED" = "Saved";
 "MNEMONIC_GENERATION_ERROR" = "We ran into a problem when trying to generate your mnemonic.";
+"SUBMIT_TRADE_TITLE" = "Confirm Trade";
+"SUBMIT_TRADE_FORMAT" = "You are about to submit a trade of %@ %@ for %@ %@.";
+"TRADE_TITLE" = "Submit";
+"TRADE_SUBMITTING_MESSAGE" = "Placing Trade Offer...";

--- a/BlockEQ/Resources/Info.plist
+++ b/BlockEQ/Resources/Info.plist
@@ -19,9 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>13</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
@@ -51,7 +53,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
 </dict>
 </plist>

--- a/BlockEQ/View Controllers/Trade/MyOffersViewController.swift
+++ b/BlockEQ/View Controllers/Trade/MyOffersViewController.swift
@@ -50,10 +50,9 @@ class MyOffersViewController: UIViewController {
                                        assetIssuer: offer.buying.assetIssuer,
                                        balance: "")
 
-        TradeOperation.postTrade(amount: 0.0000000,
-                                 price: Price(with: offer.priceR),
-                                 assets: (selling: sellingAsset, buying: buyingAsset),
-                                 offerId: offer.id) { completed in
+        TradeOperation.cancel(assets: (selling: sellingAsset, buying: buyingAsset),
+                              offerId: offer.id,
+                              price: Price(with: offer.priceR)) { completed in
             if completed {
                 self.offers.remove(at: indexPath.row)
                 self.tableView.reloadData()

--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ target 'BlockEQ' do
   # Pods for BlockEQ
   use_frameworks!
 
-  pod 'stellar-ios-mac-sdk', :git => 'https://github.com/Soneso/stellar-ios-mac-sdk', :branch => 'master'
+  pod 'stellar-ios-mac-sdk', '~> 1.4.7'
   pod 'KeychainSwift', '~> 10.0'
   pod 'Alamofire', '~> 4.7'
   pod 'SCLAlertView', :git => 'https://github.com/vikmeup/SCLAlertView-Swift', :branch => 'master'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - KeychainSwift (10.0.0)
   - Kingfisher (4.10.0)
   - SCLAlertView (0.8.1)
-  - stellar-ios-mac-sdk (1.4.6)
+  - stellar-ios-mac-sdk (1.4.7)
   - Whisper (6.0.2)
 
 DEPENDENCIES:
@@ -11,45 +11,40 @@ DEPENDENCIES:
   - KeychainSwift (~> 10.0)
   - Kingfisher (~> 4.10)
   - SCLAlertView (from `https://github.com/vikmeup/SCLAlertView-Swift`, branch `master`)
-  - stellar-ios-mac-sdk (from `https://github.com/Soneso/stellar-ios-mac-sdk`, branch `master`)
-  - "Whisper (from `git@github.com:freeubi/Whisper.git`, branch `swift-4.2-support`)"
+  - stellar-ios-mac-sdk (~> 1.4.7)
+  - Whisper (from `https://github.com/freeubi/Whisper.git`, branch `swift-4.2-support`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - Alamofire
     - KeychainSwift
     - Kingfisher
+    - stellar-ios-mac-sdk
 
 EXTERNAL SOURCES:
   SCLAlertView:
     :branch: master
     :git: https://github.com/vikmeup/SCLAlertView-Swift
-  stellar-ios-mac-sdk:
-    :branch: master
-    :git: https://github.com/Soneso/stellar-ios-mac-sdk
   Whisper:
     :branch: swift-4.2-support
-    :git: "git@github.com:freeubi/Whisper.git"
+    :git: https://github.com/freeubi/Whisper.git
 
 CHECKOUT OPTIONS:
   SCLAlertView:
     :commit: d371170ca2e276462ff229e675a2d2020ad2bb72
     :git: https://github.com/vikmeup/SCLAlertView-Swift
-  stellar-ios-mac-sdk:
-    :commit: a47c45f7207a6eac8ddbd5f960b6ec535125a3d3
-    :git: https://github.com/Soneso/stellar-ios-mac-sdk
   Whisper:
     :commit: 86880dea149a871ec5cb909cc3b93e7fb5804788
-    :git: "git@github.com:freeubi/Whisper.git"
+    :git: https://github.com/freeubi/Whisper.git
 
 SPEC CHECKSUMS:
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   KeychainSwift: f9f7910449a0c0fd2cabc889121530dd2c477c33
   Kingfisher: 43c4b802d8b5256cf1f4379e9cd10b329be6d3e2
   SCLAlertView: 9fea8ac145c0bd4989ef6abe1d3859b48f458986
-  stellar-ios-mac-sdk: fe160a0e38f318dc023548a278bc02915f80815d
+  stellar-ios-mac-sdk: 112012a49569b60afaa38dea99bf914d7ac9a32c
   Whisper: 8c499b08f3b56d5c80162d775e3462318ad7f4fe
 
-PODFILE CHECKSUM: 10fc0ed97c459d5dc980f726ff53a793a0b98f5b
+PODFILE CHECKSUM: 3e8687f3710aeb3aebab6132c0834848718eb99b
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects the truncation of decimals after the Soneso SDK was updated to only accept `Int32` parameters in the `Price` object.

It also adds a confirmation prompt when trading, so the user has an additional confirmation step.

## Screenshot
<img width="514" alt="screenshot 2018-10-16 00 19 23" src="https://user-images.githubusercontent.com/728690/46992674-3aeea880-d0d9-11e8-938a-bf0b99fb920d.png">
<img width="514" alt="screenshot 2018-10-16 00 19 27" src="https://user-images.githubusercontent.com/728690/46992675-3aeea880-d0d9-11e8-811b-596196a2771d.png">
<img width="514" alt="screenshot 2018-10-16 00 19 39" src="https://user-images.githubusercontent.com/728690/46992676-3aeea880-d0d9-11e8-892f-810aca42600f.png">

## Notes
The way this was fixed progressively scales the `numerator` and `denominator` to take the `max()` of the exponent of either value, and finding the maximum value we can scale the numerator and denominator by without overflowing the 32-bit integers used in the `Price` object.