### PR TITLE
[FIX] Remove required parameter for trust limit on 'ChangeTrustOperation'

### DIFF
--- a/BlockEQ/Operations/PaymentTransactionOperation.swift
+++ b/BlockEQ/Operations/PaymentTransactionOperation.swift
@@ -136,7 +136,7 @@ class PaymentTransactionOperation: NSObject {
 
     static func changeTrust(issuerAccountId: String,
                             assetCode: String,
-                            limit: Decimal,
+                            limit: Decimal?,
                             completion: @escaping (Bool) -> Void) {
 
         guard let sourceKeyPair = KeychainHelper.walletKeyPair else {
@@ -195,7 +195,7 @@ class PaymentTransactionOperation: NSObject {
 
     static func changeP2PTrust(issuerAccountId: String,
                                assetCode: String,
-                               limit: Decimal,
+                               limit: Decimal?,
                                completion: @escaping (Bool) -> Void) {
         guard let sourceKeyPair = KeychainHelper.walletKeyPair else {
             DispatchQueue.main.async { completion(false) }

--- a/BlockEQ/View Controllers/P2P/AddPeerViewController.swift
+++ b/BlockEQ/View Controllers/P2P/AddPeerViewController.swift
@@ -113,7 +113,7 @@ class AddPeerViewController: UIViewController {
  * Operations
  */
 extension AddPeerViewController {
-    func createTrustLine(issuerAccountId: String, assetCode: String, limit: Decimal) {
+    func createTrustLine(issuerAccountId: String, assetCode: String, limit: Decimal?) {
         showHud()
 
         PaymentTransactionOperation.changeP2PTrust(issuerAccountId: issuerAccountId,

--- a/BlockEQ/View Controllers/Wallet/AddAssetViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/AddAssetViewController.swift
@@ -77,7 +77,7 @@ extension AddAssetViewController {
 
         PaymentTransactionOperation.changeTrust(issuerAccountId: issuerAccountId,
                                                 assetCode: assetCode,
-                                                limit: 10000000000) { completed in
+                                                limit: nil) { completed in
             if completed {
                 self.getAccountDetails()
             } else {

--- a/BlockEQ/View Controllers/Wallet/WalletSwitchingViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/WalletSwitchingViewController.swift
@@ -277,7 +277,7 @@ extension WalletSwitchingViewController: WalletItemCellDelegate {
         let item = allAssets[indexPath.row]
         createTrustLine(issuerAccountId: item.assetIssuer!,
                         assetCode: item.shortCode,
-                        limit: 0.0000000,
+                        limit: 0.0,
                         isAdding: false)
     }
 }
@@ -290,7 +290,7 @@ extension WalletSwitchingViewController: WalletItemActivateCellDelegate {
             let item = updatedSupportedAssets[indexPath.row]
             createTrustLine(issuerAccountId: item.issuerAccount,
                             assetCode: item.shortForm,
-                            limit: 10000000000,
+                            limit: nil,
                             isAdding: true)
         }
     }
@@ -300,7 +300,7 @@ extension WalletSwitchingViewController: WalletItemActivateCellDelegate {
  * Operations
  */
 extension WalletSwitchingViewController {
-    func createTrustLine(issuerAccountId: String, assetCode: String, limit: Decimal, isAdding: Bool) {
+    func createTrustLine(issuerAccountId: String, assetCode: String, limit: Decimal?, isAdding: Bool) {
         let message = isAdding ? "ACTIVATE_ASSET".localized() : "REMOVE_ASSET".localized()
         showHud(message: message)
 


### PR DESCRIPTION
## Priority
Normal

## Description
This PR changes the requirement of a non-optional `limit` parameter on any `ChangeTrustOperation`. Since https://github.com/Soneso/stellar-ios-mac-sdk/commit/5ccef638b90925354a628ef42b0934c5f92e8f92 was recently implemented, we no longer require this parameter to any of our operations.

## Screenshot
N/A