### PR TITLE
[FIX] Streaming payment support

### DIFF
--- a/BlockEQ/Coordinators/ApplicationCoordinator+Extensions.swift
+++ b/BlockEQ/Coordinators/ApplicationCoordinator+Extensions.swift
@@ -210,7 +210,7 @@ extension ApplicationCoordinator: StellarAccountServiceDelegate {
         self.tradingCoordinator.update(with: account)
     }
 
-    func paymentReceived(_ service: StellarAccountService, operation: StellarOperation) {
-        print("account operation: \(operation)")
+    func paymentUpdate(_ service: StellarAccountService, operation: StellarOperation) {
+        service.update()
     }
 }

--- a/StellarAccountService/Services/StellarAccountService+Internal.swift
+++ b/StellarAccountService/Services/StellarAccountService+Internal.swift
@@ -56,7 +56,7 @@ extension StellarAccountService {
                 if operationResponse is PaymentOperationResponse {
                     let operation = StellarOperation(response: operationResponse)
                     DispatchQueue.main.async {
-                        self.delegate?.paymentReceived(self, operation: operation)
+                        self.delegate?.paymentUpdate(self, operation: operation)
                     }
                 }
             case .error(let error):

--- a/StellarAccountService/Services/StellarAccountService.swift
+++ b/StellarAccountService/Services/StellarAccountService.swift
@@ -11,7 +11,7 @@ import stellarsdk
 public protocol StellarAccountServiceDelegate: AnyObject {
     func accountUpdated(_ service: StellarAccountService, account: StellarAccount, opts: StellarAccount.UpdateOptions)
     func accountInactive(_ service: StellarAccountService, account: StellarAccount)
-    func paymentReceived(_ service: StellarAccountService, operation: StellarOperation)
+    func paymentUpdate(_ service: StellarAccountService, operation: StellarOperation)
 }
 
 /**


### PR DESCRIPTION
## Priority
Normal

## Description
This PR corrects streaming payments by initiating an account update when a payment notification is streamed to the app.

## Screenshot
![fixed](https://user-images.githubusercontent.com/728690/47695158-0a2d6980-dbd7-11e8-9b2f-e847752545f3.gif)

## Notes
This doesn't append the received operation and its effects to the existing account as a minimal update to the account.

I opted to trigger a fetch of the user's account again in order to recalculate available balance, minimum balances, etc...