### PR TITLE
[FIX] Representing trades properly in effect history

### DIFF
--- a/BlockEQ/Objects/StellarEffect+Extensions.swift
+++ b/BlockEQ/Objects/StellarEffect+Extensions.swift
@@ -33,8 +33,10 @@ extension StellarEffect {
     }
 
     public func formattedDescription(asset: StellarAsset) -> String {
-        if type == .tradeEffect {
-            return ""
+        if self.type == .tradeEffect {
+            return String(format: "TRADE_CURRENCY_PAIR_FORMAT".localized(),
+                          assetPair.selling.shortCode,
+                          assetPair.buying.shortCode)
         } else {
             return type.title
         }

--- a/StellarAccountService/Objects/StellarEffect.swift
+++ b/StellarAccountService/Objects/StellarEffect.swift
@@ -19,14 +19,8 @@ public final class StellarEffect {
                                            assetCode: nil,
                                            assetIssuer: nil,
                                            balance: "")
-    var soldAsset: StellarAsset = StellarAsset(assetType: AssetTypeAsString.NATIVE,
-                                               assetCode: nil,
-                                               assetIssuer: nil,
-                                               balance: "")
-    var boughtAsset: StellarAsset = StellarAsset(assetType: AssetTypeAsString.NATIVE,
-                                                 assetCode: nil,
-                                                 assetIssuer: nil,
-                                                 balance: "")
+
+    public private(set) var assetPair = StellarAssetPair(buying: StellarAsset.lumens, selling: StellarAsset.lumens)
 
     init(response: EffectResponse) {
         self.identifier = response.id
@@ -80,27 +74,26 @@ public final class StellarEffect {
             return
         }
 
-        soldAsset = StellarAsset(assetType: updatedEffect.soldAssetType,
-                                 assetCode: updatedEffect.soldAssetCode,
-                                 assetIssuer: updatedEffect.soldAssetIssuer,
-                                 balance: "")
+        let selling = StellarAsset(assetType: updatedEffect.soldAssetType,
+                                         assetCode: updatedEffect.soldAssetCode,
+                                         assetIssuer: updatedEffect.soldAssetIssuer,
+                                         balance: "")
 
-        boughtAsset = StellarAsset(assetType: updatedEffect.boughtAssetType,
-                                   assetCode: updatedEffect.boughtAssetCode,
-                                   assetIssuer: updatedEffect.boughtAssetIssuer,
-                                   balance: "")
+        let buying = StellarAsset(assetType: updatedEffect.boughtAssetType,
+                                        assetCode: updatedEffect.boughtAssetCode,
+                                        assetIssuer: updatedEffect.boughtAssetIssuer,
+                                        balance: "")
+
+        self.assetPair = StellarAssetPair(buying: buying, selling: selling)
 
         boughtAmount = updatedEffect.boughtAmount
         soldAmount = updatedEffect.soldAmount
     }
 
     private func setInflationEffect(with effectResponse: EffectResponse) {
-//        guard let updatedEffect = effectResponse as? AccountInflationDestinationUpdatedEffectResponse else {
-//            return
-//        }
     }
 
     public func isBought(asset: StellarAsset) -> Bool {
-        return asset == boughtAsset
+        return asset == self.assetPair.buying
     }
 }

--- a/StellarAccountService/Operations/Account/FetchAccountEffectsOperation.swift
+++ b/StellarAccountService/Operations/Account/FetchAccountEffectsOperation.swift
@@ -30,7 +30,7 @@ final class FetchAccountEffectsOperation: AsyncOperation {
     override func main() {
         super.main()
 
-        horizon.effects.getEffects(forAccount: self.accountId, from: nil, order: .ascending, limit: 200) { response in
+        horizon.effects.getEffects(forAccount: self.accountId, from: nil, order: .descending, limit: 200) { response in
             switch response {
             case .success(let effectsResponse):
                 let effects = effectsResponse.records.map {

--- a/StellarAccountService/Operations/Account/FetchTransactionsOperation.swift
+++ b/StellarAccountService/Operations/Account/FetchTransactionsOperation.swift
@@ -30,7 +30,7 @@ final class FetchTransactionsOperation: AsyncOperation {
     override func main() {
         super.main()
 
-        horizon.transactions.getTransactions(forAccount: accountId, from: nil, order: .ascending, limit: 200) { resp in
+        horizon.transactions.getTransactions(forAccount: accountId, from: nil, order: .descending, limit: 200) { resp in
             switch resp {
             case .success(let response):
                 let transactions = response.records

--- a/StellarAccountService/Operations/Trade/FetchOffersOperation.swift
+++ b/StellarAccountService/Operations/Trade/FetchOffersOperation.swift
@@ -36,7 +36,7 @@ final class FetchOffersOperation: AsyncOperation {
         super.main()
 
         let acc = address.string
-        horizon.offers.getOffers(forAccount: acc, cursor: nil, order: Order.ascending, limit: recordCount) { response in
+        horizon.offers.getOffers(forAccount: acc, cursor: nil, order: .descending, limit: recordCount) { response in
             switch response {
             case .success(let offerResponse):
                 let offers = offerResponse.records.compactMap { StellarAccountOffer($0) }


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects the treatment of trading effects in the `WalletViewController`. Effects are now fetched from `now - 200` records.

## Screenshot
![81dcaf81-f155-45cd-a136-4d9210d0ff11](https://user-images.githubusercontent.com/728690/47764952-13cdd480-dc9e-11e8-8e7e-ac356a6aa47e.png)
