### PR TITLE
[FIX] Better prompt when updating the inflation destination

### DIFF
--- a/BlockEQ/Coordinators/ApplicationCoordinator+Extensions.swift
+++ b/BlockEQ/Coordinators/ApplicationCoordinator+Extensions.swift
@@ -131,11 +131,12 @@ extension ApplicationCoordinator: WalletSwitchingViewControllerDelegate {
         }
     }
 
-    func updateInflation(destination: StellarAddress) {
+    func updateInflation() {
         guard let account = core?.accountService.account else { return }
 
-        let inflationViewController = InflationViewController(account: account, inflationDestination: destination)
+        let inflationViewController = InflationViewController(account: account)
         self.inflationViewController = inflationViewController
+        self.inflationViewController?.delegate = self
 
         if let container = walletViewController.navigationContainer {
             container.pushViewController(inflationViewController, animated: true)
@@ -167,6 +168,16 @@ extension ApplicationCoordinator: WalletSwitchingViewControllerDelegate {
         }
 
         account.changeTrust(asset: asset, remove: false, delegate: walletVC)
+    }
+}
+
+extension ApplicationCoordinator: InflationViewControllerDelegate {
+    func updateAccountInflation(_ viewController: InflationViewController, destination: StellarAddress) {
+        guard let account = core?.accountService.account else {
+            return
+        }
+
+        account.setInflationDestination(address: destination, delegate: viewController)
     }
 }
 

--- a/BlockEQ/Coordinators/TradingCoordinator.swift
+++ b/BlockEQ/Coordinators/TradingCoordinator.swift
@@ -130,10 +130,10 @@ extension TradingCoordinator: WalletSwitchingViewControllerDelegate {
         self.account?.changeTrust(asset: asset, remove: false, delegate: self)
     }
 
-    func updateInflation(destination: StellarAddress) {
+    func updateInflation() {
         guard let account = self.account else { return }
 
-        let inflationViewController = InflationViewController(account: account, inflationDestination: destination)
+        let inflationViewController = InflationViewController(account: account)
 
         wrappingNavController?.pushViewController(inflationViewController, animated: true)
     }
@@ -144,6 +144,14 @@ extension TradingCoordinator: WalletSwitchingViewControllerDelegate {
         self.addAssetViewController = addAssetViewController
 
         wrappingNavController?.pushViewController(addAssetViewController, animated: true)
+    }
+}
+
+extension TradingCoordinator: InflationViewControllerDelegate {
+    func updateAccountInflation(_ viewController: InflationViewController, destination: StellarAddress) {
+        guard let account = self.account else { return }
+
+        account.setInflationDestination(address: destination, delegate: viewController)
     }
 }
 

--- a/BlockEQ/Data Sources/WalletSwitchingTableViewDataSource.swift
+++ b/BlockEQ/Data Sources/WalletSwitchingTableViewDataSource.swift
@@ -9,7 +9,7 @@
 import StellarAccountService
 
 protocol WalletDataSourceDelegate: AnyObject {
-    func updateInflation(_ dataSource: WalletSwitchingDataSource, destination: StellarAddress)
+    func updateInflation(_ dataSource: WalletSwitchingDataSource)
     func createTrustLine(_ dataSource: WalletSwitchingDataSource, to address: StellarAddress, asset: StellarAsset)
     func remove(_ dataSource: WalletSwitchingDataSource, asset: StellarAsset)
     func add(_ dataSource: WalletSwitchingDataSource, asset: StellarAsset)
@@ -129,8 +129,7 @@ extension WalletSwitchingDataSource: UITableViewDataSource {
 
 extension WalletSwitchingDataSource: WalletItemCellDelegate {
     func requestedChangeInflation() {
-        guard let address = stellarAccount.inflationAddress else { return }
-        delegate?.updateInflation(self, destination: address)
+        delegate?.updateInflation(self)
     }
 
     func requestedRemoveAsset(indexPath: IndexPath) {

--- a/BlockEQ/Data Sources/WalletTableViewDataSource.swift
+++ b/BlockEQ/Data Sources/WalletTableViewDataSource.swift
@@ -37,9 +37,9 @@ final class WalletTableViewDataSource: NSObject {
     init(account: StellarAccount, asset: StellarAsset) {
         self.index = account.assets.firstIndex(of: asset)
         self.account = account
-        self.effects = account.effects.filter {
-            $0.asset == asset && WalletTableViewDataSource.supportedEffects.contains($0.type)
-        }
+        self.effects = account.effects
+            .filter { $0.asset == asset && WalletTableViewDataSource.supportedEffects.contains($0.type) }
+            .sorted(by: { (first, second) -> Bool in first.createdAt > second.createdAt })
     }
 }
 

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -164,3 +164,5 @@
 "SENDING_PAYMENT" = "Sending Payment...";
 "SETTING_INFLATION_DESTINATION" = "Setting Inflation Destination...";
 "INFLATION_SUCCESSFULLY_UPDATED" = "Inflation successfully updated.";
+"INVALID_DESTINATION_TITLE" = "Invalid destination";
+"INFLATION_DESTINATION_INVALID" = "Unable to update the inflation destination to your own account, or the account it's already set to.";

--- a/BlockEQ/View Controllers/Wallet/WalletSwitchingViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/WalletSwitchingViewController.swift
@@ -16,7 +16,7 @@ protocol WalletSwitchingViewControllerDelegate: class {
     func selectedAddAsset()
 
     func createTrustLine(to address: StellarAddress, for asset: StellarAsset)
-    func updateInflation(destination: StellarAddress)
+    func updateInflation()
     func remove(asset: StellarAsset)
     func add(asset: StellarAsset)
 }
@@ -147,6 +147,15 @@ final class WalletSwitchingViewController: UIViewController {
     }
 }
 
+extension WalletSwitchingViewController: AccountUpdatable {
+    func update(account: StellarAccount) {
+        rebuildDataSource(using: account)
+        tableView?.reloadData()
+
+        hideHud()
+    }
+}
+
 extension WalletSwitchingViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let section = WalletSwitchingDataSource.Section(rawValue: section),
@@ -204,11 +213,11 @@ extension WalletSwitchingViewController: WalletDataSourceDelegate {
         delegate?.add(asset: asset)
     }
 
-    func updateInflation(_ dataSource: WalletSwitchingDataSource, destination: StellarAddress) {
+    func updateInflation(_ dataSource: WalletSwitchingDataSource) {
         if dataSource.isZeroBalance() {
             displayNoBalanceError()
         } else {
-            delegate?.updateInflation(destination: destination)
+            delegate?.updateInflation()
         }
     }
 }


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects a poor UX choice in simply shaking the inflation destination field when it was either:
1) Your own account
2) The account you've already set the inflation destination to

Now, a prompt indicating the problem has been implemented to better inform the user as to what's wrong.

## Screenshot
<img width="545" alt="screenshot 2018-10-31 16 27 26" src="https://user-images.githubusercontent.com/728690/47816564-dd3d9b80-dd29-11e8-8453-09ae7a7e6587.png">


## Additional Notes
* Reorganize delegation structure for inflation setting
