### PR TITLE
[FIX] Correct warnings relating to UIStatusBarStyle

### DIFF
--- a/BlockEQ/Coordinators/ApplicationCoordinator.swift
+++ b/BlockEQ/Coordinators/ApplicationCoordinator.swift
@@ -295,7 +295,7 @@ extension ApplicationCoordinator: SettingsDelegate {
             self.displayAuth {
                 KeychainHelper.clearAll()
                 SecurityOptionHelper.clear()
-                try? self.core?.accountService.clear()
+                self.core?.accountService.clear()
                 self.core = nil
                 self.delegate?.switchToOnboarding()
             }

--- a/BlockEQ/View Controllers/Security/BlankAuthenticationViewController.swift
+++ b/BlockEQ/View Controllers/Security/BlankAuthenticationViewController.swift
@@ -23,7 +23,6 @@ final class BlankAuthenticationViewController: UIViewController {
     override var preferredStatusBarStyle: UIStatusBarStyle { return .lightContent }
 
     func setupView() {
-        UIApplication.shared.statusBarStyle = .lightContent
         self.view.backgroundColor = Colors.backgroundDark
         self.authLogo.image = UIImage(named: "logo")
         self.authLogo.contentMode = .top
@@ -31,18 +30,14 @@ final class BlankAuthenticationViewController: UIViewController {
         self.authButton.alpha = 0
         self.authButton.setTitle("AUTHENTICATE_TITLE".localized(), for: .normal)
         self.authButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .title3)
+
+        self.setNeedsStatusBarAppearanceUpdate()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         setupView()
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        UIApplication.shared.statusBarStyle = .default
     }
 
     func displayAuthButton() {

--- a/BlockEQ/View Controllers/Security/PinViewController.swift
+++ b/BlockEQ/View Controllers/Security/PinViewController.swift
@@ -68,7 +68,6 @@ class PinViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        UIApplication.shared.statusBarStyle = .lightContent
         impactGenerator.prepare()
 
         var pinDotColor: UIColor
@@ -107,12 +106,8 @@ class PinViewController: UIViewController {
             pinView.update(with: viewModel)
             pinView.reset()
         }
-    }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        UIApplication.shared.statusBarStyle = .default
+        self.setNeedsStatusBarAppearanceUpdate()
     }
 
     func setupView() {


### PR DESCRIPTION
## Priority
Low

## Description
Removing deprecated usage of setting global `UIStatusBarStyle`.

## Screenshot
<img width="545" alt="screenshot 2018-10-31 17 08 13" src="https://user-images.githubusercontent.com/728690/47819029-ab2f3800-dd2f-11e8-82fd-066e6154b48d.png">