### PR TITLE
[FIX] Displays '< 0.0001' for small amounts of assets

### DIFF
--- a/BlockEQ/Data Sources/WalletSwitchingTableViewDataSource.swift
+++ b/BlockEQ/Data Sources/WalletSwitchingTableViewDataSource.swift
@@ -86,7 +86,7 @@ extension WalletSwitchingDataSource: UITableViewDataSource {
             let item = allAssets[indexPath.row]
             let walletCell: WalletItemCell = tableView.dequeueReusableCell(for: indexPath)
             var viewModel = WalletItemCell.ViewModel(title: Assets.displayTitle(shortCode: item.shortCode),
-                                                     amount: "\(item.formattedBalance) \(item.shortCode)")
+                                                     amount: "\(item.balance.decimalFormatted) \(item.shortCode)")
 
             walletCell.indexPath = indexPath
             walletCell.delegate = self

--- a/BlockEQ/Extensions/String+DecimalFormatter.swift
+++ b/BlockEQ/Extensions/String+DecimalFormatter.swift
@@ -22,7 +22,12 @@ extension Formatter {
 
 extension String {
     var decimalFormatted: String {
-        return Formatter.displayFormatters.string(for: self.doubleValue) ?? ""
+        let value = self.doubleValue
+        if value > 0 && value <= 0.0001 {
+            return "< 0.0001"
+        } else {
+            return Formatter.displayFormatters.string(for: value) ?? ""
+        }
     }
 
     var doubleValue: Double {
@@ -36,12 +41,20 @@ extension String {
 
 extension Decimal {
     var displayFormattedString: String {
-        return Formatter.displayFormatters.string(for: self) ?? ""
+        if self > 0 && self <= 0.0001 {
+            return "< 0.0001"
+        } else {
+            return Formatter.displayFormatters.string(for: self) ?? ""
+        }
     }
 }
 
 extension Double {
     var displayFormattedString: String {
-        return Formatter.displayFormatters.string(for: self) ?? ""
+        if self > 0 && self <= 0.0001 {
+            return "< 0.0001"
+        } else {
+            return Formatter.displayFormatters.string(for: self) ?? ""
+        }
     }
 }

--- a/BlockEQ/Objects/StellarAsset+Extensions.swift
+++ b/BlockEQ/Objects/StellarAsset+Extensions.swift
@@ -75,9 +75,3 @@ public struct Assets {
         return Colors.blueGray
     }
 }
-
-extension StellarAsset {
-    public var formattedBalance: String {
-        return balance.decimalFormatted
-    }
-}

--- a/BlockEQ/View Controllers/Address Book/SelectAssetViewController.swift
+++ b/BlockEQ/View Controllers/Address Book/SelectAssetViewController.swift
@@ -90,7 +90,7 @@ extension SelectAssetViewController: UITableViewDataSource {
         if item.assetType == AssetTypeAsString.NATIVE {
             cell.amountLabel.text = "\(stellarAccount.formattedAvailableBalance) \(item.shortCode)"
         } else {
-            cell.amountLabel.text = "\(allAssets[indexPath.row].formattedBalance) \(item.shortCode)"
+            cell.amountLabel.text = "\(allAssets[indexPath.row].balance.decimalFormatted) \(item.shortCode)"
         }
 
         return cell

--- a/BlockEQ/View Controllers/P2P/TrustedPartiesViewController.swift
+++ b/BlockEQ/View Controllers/P2P/TrustedPartiesViewController.swift
@@ -100,7 +100,7 @@ extension TrustedPartiesViewController: UITableViewDataSource {
         cell.indexPath = indexPath
         cell.delegate = self
         cell.titleLabel.text = Assets.displayTitle(shortCode: item.shortCode)
-        cell.amountLabel.text = "\(item.formattedBalance) \(item.shortCode)"
+        cell.amountLabel.text = "\(item.balance.decimalFormatted) \(item.shortCode)"
         cell.iconImageView.backgroundColor = Assets.displayImageBackgroundColor(shortCode: item.shortCode)
 
         if let image = Assets.displayImage(shortCode: item.shortCode) {

--- a/BlockEQ/View Controllers/Trade/BalanceViewController.swift
+++ b/BlockEQ/View Controllers/Trade/BalanceViewController.swift
@@ -68,7 +68,7 @@ class BalanceViewController: UIViewController {
         signersAmountLabel.text = String(describing: stellarAccount.totalSigners)
         signersValueLabel.text = stellarAccount.formattedSigners
         minimumBalanceLabel.text = stellarAccount.formattedMinBalance
-        totalBalanceLabel.text = stellarAsset.formattedBalance
+        totalBalanceLabel.text = stellarAsset.balance.decimalFormatted
     }
 
     @objc func dismissView() {

--- a/BlockEQ/View Controllers/Wallet/SendAmountViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/SendAmountViewController.swift
@@ -90,7 +90,7 @@ class SendAmountViewController: UIViewController {
         if asset.assetType == AssetTypeAsString.NATIVE {
             availableBalance = stellarAccount.formattedAvailableBalance
         } else {
-            availableBalance = asset.formattedBalance
+            availableBalance = asset.balance.decimalFormatted
         }
 
         navigationItem.title = "\(availableBalance) \(asset.shortCode)"

--- a/BlockEQ/View Controllers/Wallet/SendViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/SendViewController.swift
@@ -98,7 +98,7 @@ class SendViewController: UIViewController {
         if asset.assetType == AssetTypeAsString.NATIVE {
             availableBalance = stellarAccount.formattedAvailableBalance
         } else {
-            availableBalance = asset.formattedBalance
+            availableBalance = asset.balance.decimalFormatted
         }
 
         navigationItem.title = "\(availableBalance) \(asset.shortCode)"


### PR DESCRIPTION
## Priority
Normal

## Description
Around the application - there are places where it's not clear why you can't remove an asset when the displayed amount balance is `0.00`, when the amount is actually low like `0.000001987`.

To address this, we now display `< 0.0001` for amounts below the minimum amount threshold.

## Screenshot
<img width="545" alt="screenshot 2018-10-31 18 05 48" src="https://user-images.githubusercontent.com/728690/47821650-cb62f500-dd37-11e8-8d7a-4ec26486ac67.png">
