### PR TITLE
[FIX] Corrects issue causing limit order text to be overwritten due to periodic updates

### DIFF
--- a/BlockEQ/View Controllers/Trade/TradeViewController.swift
+++ b/BlockEQ/View Controllers/Trade/TradeViewController.swift
@@ -283,7 +283,7 @@ class TradeViewController: UIViewController {
 
         currentMarketPrice = bestPrice
 
-        if let tradeFromText = tradeFromTextField.text {
+        if self.currentTradeType == .market, let tradeFromText = tradeFromTextField.text {
             setCalculatedMarketPrice(tradeFromText: tradeFromText)
         }
     }


### PR DESCRIPTION
## Priority
High

## Description
Since we've implemented the new periodic update feature for the order book on iOS, each update was overwriting text the user may have entered on the trading screen. 

This PR corrects this by only setting the `tradeToTextField` text when in `market` mode. 

![bug](https://user-images.githubusercontent.com/728690/47864172-59d68580-ddcf-11e8-8749-463fd335369f.gif)

