### PR TITLE
[FIX] Using a new decimal format for trades in the order book with more precision

### DIFF
--- a/BlockEQ/Data Sources/WalletSwitchingTableViewDataSource.swift
+++ b/BlockEQ/Data Sources/WalletSwitchingTableViewDataSource.swift
@@ -86,7 +86,7 @@ extension WalletSwitchingDataSource: UITableViewDataSource {
             let item = allAssets[indexPath.row]
             let walletCell: WalletItemCell = tableView.dequeueReusableCell(for: indexPath)
             var viewModel = WalletItemCell.ViewModel(title: Assets.displayTitle(shortCode: item.shortCode),
-                                                     amount: "\(item.balance.decimalFormatted) \(item.shortCode)")
+                                                     amount: "\(item.balance.displayFormatted) \(item.shortCode)")
 
             walletCell.indexPath = indexPath
             walletCell.delegate = self

--- a/BlockEQ/Extensions/String+DecimalFormatter.swift
+++ b/BlockEQ/Extensions/String+DecimalFormatter.swift
@@ -9,6 +9,9 @@
 import UIKit
 
 extension Formatter {
+    static let minimumDisplayString = "0.0001"
+    static let minimumDisplayAmount = Decimal(string: minimumDisplayString)!
+
     static let displayFormatters: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
@@ -18,43 +21,60 @@ extension Formatter {
         formatter.groupingSeparator = ""
         return formatter
     }()
+
+    static let tradeFormatters: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.generatesDecimalNumbers = true
+        formatter.maximumFractionDigits = 8
+        formatter.minimumFractionDigits = 2
+        formatter.groupingSeparator = ""
+        return formatter
+    }()
+
+    static func minimumAmount(with formatter: NumberFormatter, amount: Decimal) -> String {
+        if amount > 0 && amount < Formatter.minimumDisplayAmount {
+            return String(format: "CRYPTO_DUST_FORMAT_STRING".localized(), minimumDisplayString)
+        } else {
+            return formatter.string(for: amount) ?? ""
+        }
+    }
 }
 
 extension String {
-    var decimalFormatted: String {
-        let value = self.doubleValue
-        if value > 0 && value <= 0.0001 {
-            return "< 0.0001"
-        } else {
-            return Formatter.displayFormatters.string(for: value) ?? ""
-        }
+    var displayFormatted: String {
+        return Formatter.minimumAmount(with: Formatter.displayFormatters, amount: self.decimalValue)
     }
 
-    var doubleValue: Double {
-        guard let double = Double(self) else {
+    var tradeFormatted: String {
+        return Formatter.tradeFormatters.string(for: self.decimalValue) ?? ""
+    }
+
+    var decimalValue: Decimal {
+        guard let decimal = Decimal(string: self) else {
             return 0.00
         }
 
-        return double
+        return decimal
     }
 }
 
 extension Decimal {
     var displayFormattedString: String {
-        if self > 0 && self <= 0.0001 {
-            return "< 0.0001"
-        } else {
-            return Formatter.displayFormatters.string(for: self) ?? ""
-        }
+        return Formatter.minimumAmount(with: Formatter.displayFormatters, amount: self)
+    }
+
+    var tradeFormattedString: String {
+        return Formatter.tradeFormatters.string(for: self) ?? ""
     }
 }
 
 extension Double {
     var displayFormattedString: String {
-        if self > 0 && self <= 0.0001 {
-            return "< 0.0001"
-        } else {
-            return Formatter.displayFormatters.string(for: self) ?? ""
-        }
+        return Formatter.minimumAmount(with: Formatter.displayFormatters, amount: Decimal(self))
+    }
+
+    var tradeFormattedString: String {
+        return Formatter.tradeFormatters.string(for: Decimal(self)) ?? ""
     }
 }

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -166,3 +166,4 @@
 "INFLATION_SUCCESSFULLY_UPDATED" = "Inflation successfully updated.";
 "INVALID_DESTINATION_TITLE" = "Invalid destination";
 "INFLATION_DESTINATION_INVALID" = "Unable to update the inflation destination to your own account, or the account it's already set to.";
+"CRYPTO_DUST_FORMAT_STRING" = "< %@";

--- a/BlockEQ/View Controllers/Address Book/SelectAssetViewController.swift
+++ b/BlockEQ/View Controllers/Address Book/SelectAssetViewController.swift
@@ -90,7 +90,7 @@ extension SelectAssetViewController: UITableViewDataSource {
         if item.assetType == AssetTypeAsString.NATIVE {
             cell.amountLabel.text = "\(stellarAccount.formattedAvailableBalance) \(item.shortCode)"
         } else {
-            cell.amountLabel.text = "\(allAssets[indexPath.row].balance.decimalFormatted) \(item.shortCode)"
+            cell.amountLabel.text = "\(allAssets[indexPath.row].balance.displayFormatted) \(item.shortCode)"
         }
 
         return cell

--- a/BlockEQ/View Controllers/P2P/TrustedPartiesViewController.swift
+++ b/BlockEQ/View Controllers/P2P/TrustedPartiesViewController.swift
@@ -100,7 +100,7 @@ extension TrustedPartiesViewController: UITableViewDataSource {
         cell.indexPath = indexPath
         cell.delegate = self
         cell.titleLabel.text = Assets.displayTitle(shortCode: item.shortCode)
-        cell.amountLabel.text = "\(item.balance.decimalFormatted) \(item.shortCode)"
+        cell.amountLabel.text = "\(item.balance.displayFormatted) \(item.shortCode)"
         cell.iconImageView.backgroundColor = Assets.displayImageBackgroundColor(shortCode: item.shortCode)
 
         if let image = Assets.displayImage(shortCode: item.shortCode) {

--- a/BlockEQ/View Controllers/Trade/BalanceViewController.swift
+++ b/BlockEQ/View Controllers/Trade/BalanceViewController.swift
@@ -68,7 +68,7 @@ class BalanceViewController: UIViewController {
         signersAmountLabel.text = String(describing: stellarAccount.totalSigners)
         signersValueLabel.text = stellarAccount.formattedSigners
         minimumBalanceLabel.text = stellarAccount.formattedMinBalance
-        totalBalanceLabel.text = stellarAsset.balance.decimalFormatted
+        totalBalanceLabel.text = stellarAsset.balance.displayFormatted
     }
 
     @objc func dismissView() {

--- a/BlockEQ/View Controllers/Trade/MyOffersViewController.swift
+++ b/BlockEQ/View Controllers/Trade/MyOffersViewController.swift
@@ -96,7 +96,7 @@ extension MyOffersViewController: UITableViewDataSource {
                           Assets.cellDisplay(shortCode: offer.sellingAsset.assetCode),
                           offer.value.displayFormattedString,
                           Assets.cellDisplay(shortCode: offer.buyingAsset.assetCode),
-                          offer.price.decimalFormatted)
+                          offer.price.displayFormatted)
 
         cell.offerLabel.text = text
 

--- a/BlockEQ/View Controllers/Trade/OrderBookViewController.swift
+++ b/BlockEQ/View Controllers/Trade/OrderBookViewController.swift
@@ -107,13 +107,13 @@ extension OrderBookViewController: UITableViewDataSource {
         let cell: OrderBookCell = tableView.dequeueReusableCell(for: indexPath)
 
         let item = bids[indexPath.row]
-        let numerator = Double(item.numerator)
-        let denominator = Double(item.denominator)
-        let result = denominator / numerator * item.amount.doubleValue
+        let numerator = Decimal(item.numerator)
+        let denominator = Decimal(item.denominator)
+        let result = denominator / numerator * item.amount.decimalValue
 
-        cell.option1Label.text = item.price.decimalFormatted
-        cell.option2Label.text = result.displayFormattedString
-        cell.option3Label.text = item.amount.decimalFormatted
+        cell.option1Label.text = item.price.tradeFormatted
+        cell.option2Label.text = result.tradeFormattedString
+        cell.option3Label.text = item.amount.tradeFormatted
 
         return cell
     }
@@ -122,9 +122,9 @@ extension OrderBookViewController: UITableViewDataSource {
         let cell: OrderBookCell = tableView.dequeueReusableCell(for: indexPath)
 
         let item = asks[indexPath.row]
-        cell.option1Label.text = item.price.decimalFormatted
-        cell.option2Label.text = item.amount.decimalFormatted
-        cell.option3Label.text = item.value.displayFormattedString
+        cell.option1Label.text = item.price.tradeFormatted
+        cell.option2Label.text = item.amount.tradeFormatted
+        cell.option3Label.text = item.value.tradeFormattedString
 
         return cell
     }

--- a/BlockEQ/View Controllers/Trade/TradeViewController.swift
+++ b/BlockEQ/View Controllers/Trade/TradeViewController.swift
@@ -214,7 +214,7 @@ class TradeViewController: UIViewController {
         }
 
         var formatString = "TRADE_BALANCE_FORMAT"
-        var balanceAmount = fromAsset.balance.decimalFormatted
+        var balanceAmount = fromAsset.balance.displayFormatted
 
         if fromAsset.isNative {
             formatString = "TRADE_BALANCE_AVAILABLE_FORMAT"
@@ -254,7 +254,7 @@ class TradeViewController: UIViewController {
             tradeFromButton.setTitle(fromAsset?.shortCode, for: .normal)
 
             if let fromAsset = fromAsset {
-                balanceLabel.text = "\(fromAsset.balance.decimalFormatted) \(fromAsset.shortCode)"
+                balanceLabel.text = "\(fromAsset.balance.displayFormatted) \(fromAsset.shortCode)"
             }
 
             toAssetToRemove = fromAsset

--- a/BlockEQ/View Controllers/Wallet/SendAmountViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/SendAmountViewController.swift
@@ -90,7 +90,7 @@ class SendAmountViewController: UIViewController {
         if asset.assetType == AssetTypeAsString.NATIVE {
             availableBalance = stellarAccount.formattedAvailableBalance
         } else {
-            availableBalance = asset.balance.decimalFormatted
+            availableBalance = asset.balance.displayFormatted
         }
 
         navigationItem.title = "\(availableBalance) \(asset.shortCode)"

--- a/BlockEQ/View Controllers/Wallet/SendViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/SendViewController.swift
@@ -98,7 +98,7 @@ class SendViewController: UIViewController {
         if asset.assetType == AssetTypeAsString.NATIVE {
             availableBalance = stellarAccount.formattedAvailableBalance
         } else {
-            availableBalance = asset.balance.decimalFormatted
+            availableBalance = asset.balance.displayFormatted
         }
 
         navigationItem.title = "\(availableBalance) \(asset.shortCode)"

--- a/BlockEQ/View Controllers/Wallet/WalletViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/WalletViewController.swift
@@ -124,7 +124,7 @@ class WalletViewController: UIViewController {
         if let asset = self.dataSource?.asset, let account = self.dataSource?.account {
             self.showNativeHeader = asset.isNative
             self.coinLabel.text = Assets.formattedDisplayTitle(asset: asset)
-            self.balanceLabel.text = asset.balance.decimalFormatted
+            self.balanceLabel.text = asset.balance.displayFormatted
             self.availableBalanceLabel.text = account.formattedAvailableBalance(for: asset)
         }
     }


### PR DESCRIPTION
## Priority
High

## Description
While correcting the behaviour of the order book, I noticed the currently released app on the App Store had a lot of values as 0.00 in order rows. This is hard to read and understand the listed value of the offer, so this PR introduces a new decimal format for the order book in order to address this issue.

**Decimal formatted:** To be used in small cells where there's not a lot of 
**Trade formatted:** To be used for high-precision display of crypto amounts

**Trade formatted strings:**
 -> Minumum decimals: 2
 -> Maximum decimals: 8

**Display formatted strings:**
 -> Minumum decimals: 2
 -> Maximum decimals: 4

## Before (Currently released app on the App Store)
![img_0126](https://user-images.githubusercontent.com/728690/47871756-41706600-dde3-11e8-8d41-35ca4dd2b92c.jpg)

## After (Unreleased local build)
![simulator screen shot - ipad pro 10 5-inch - 2018-11-01 at 15 37 02](https://user-images.githubusercontent.com/728690/47875091-00c91a80-ddec-11e8-9720-aad6223f60ad.png)

