### PR TITLE
[FEATURE] Adds some tests for StellarAccount+Operations

### DIFF
--- a/BlockEQ/View Controllers/Wallet/InflationViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/InflationViewController.swift
@@ -137,12 +137,7 @@ extension InflationViewController: ScanViewControllerDelegate {
 
 // MARK: - SetInflationResponseDelegate
 extension InflationViewController: SetInflationResponseDelegate {
-    func setInflation(destination: StellarAddress) {
-        self.hideHud()
-        self.displayInflationSuccess()
-    }
-
-    func failed(error: Error) {
+    func failed(error: StellarAccountService.ServiceError) {
         self.hideHud()
         let alert = UIAlertController(title: "INFLATION_ERROR_TITLE".localized(),
                                       message: "INFLATION_ERROR_MESSAGE".localized(),
@@ -151,5 +146,10 @@ extension InflationViewController: SetInflationResponseDelegate {
         alert.addAction(UIAlertAction(title: "GENERIC_OK_TEXT".localized(), style: .default, handler: nil))
 
         self.present(alert, animated: true, completion: nil)
+    }
+
+    func setInflation(destination: StellarAddress) {
+        self.hideHud()
+        self.displayInflationSuccess()
     }
 }

--- a/StellarAccountService.xcodeproj/project.pbxproj
+++ b/StellarAccountService.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		C593DFF2218C0F2C00FA01DD /* StellarAccountOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C593DFF1218C0F2C00FA01DD /* StellarAccountOperationTests.swift */; };
 		C593DFF4218C10C100FA01DD /* account_response.json in Resources */ = {isa = PBXBuildFile; fileRef = C593DFF3218C10C100FA01DD /* account_response.json */; };
 		C593DFF6218C12DB00FA01DD /* no_balance_account_response.json in Resources */ = {isa = PBXBuildFile; fileRef = C593DFF5218C12DB00FA01DD /* no_balance_account_response.json */; };
+		C5B37B08218CECB400F9937D /* TestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5B37B07218CECB400F9937D /* TestObjects.swift */; };
 		C5D8CAC9218111CC009F8624 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D8CAC8218111CC009F8624 /* Protocols.swift */; };
 		C5D8CACB218112CC009F8624 /* StellarAccount+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D8CACA218112CC009F8624 /* StellarAccount+Operations.swift */; };
 		C5D8CACD21812245009F8624 /* StellarPaymentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D8CACC21812245009F8624 /* StellarPaymentData.swift */; };
@@ -139,6 +140,7 @@
 		C593DFF1218C0F2C00FA01DD /* StellarAccountOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StellarAccountOperationTests.swift; sourceTree = "<group>"; };
 		C593DFF3218C10C100FA01DD /* account_response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = account_response.json; sourceTree = "<group>"; };
 		C593DFF5218C12DB00FA01DD /* no_balance_account_response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = no_balance_account_response.json; sourceTree = "<group>"; };
+		C5B37B07218CECB400F9937D /* TestObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestObjects.swift; sourceTree = "<group>"; };
 		C5D8CAC8218111CC009F8624 /* Protocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; };
 		C5D8CACA218112CC009F8624 /* StellarAccount+Operations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StellarAccount+Operations.swift"; sourceTree = "<group>"; };
 		C5D8CACC21812245009F8624 /* StellarPaymentData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StellarPaymentData.swift; sourceTree = "<group>"; };
@@ -271,6 +273,13 @@
 			path = Tools;
 			sourceTree = "<group>";
 		};
+		C5B37B06218CC94500F9937D /* Operations */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Operations;
+			sourceTree = "<group>";
+		};
 		C5D8CADA2183A792009F8624 /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -329,10 +338,12 @@
 		C5F1C9DC217A7B61001C847A /* StellarAccountServiceTests */ = {
 			isa = PBXGroup;
 			children = (
+				C5B37B06218CC94500F9937D /* Operations */,
 				C5FE757D218BCBD10090E372 /* Objects */,
 				C5FE758B218BD70B0090E372 /* Utilities */,
 				C5FE7586218BD56D0090E372 /* Fixtures */,
 				C5F1C9DF217A7B61001C847A /* Info.plist */,
+				C5B37B07218CECB400F9937D /* TestObjects.swift */,
 			);
 			path = StellarAccountServiceTests;
 			sourceTree = "<group>";
@@ -728,6 +739,7 @@
 				C5FE759B218BE7BA0090E372 /* StellarPaymentDataTests.swift in Sources */,
 				C5FE757A218BC7EE0090E372 /* StellarAddressTests.swift in Sources */,
 				C593DFDC218C03D000FA01DD /* StellarOperationTests.swift in Sources */,
+				C5B37B08218CECB400F9937D /* TestObjects.swift in Sources */,
 				C5FE759D218BF06A0090E372 /* StellarAssetTests.swift in Sources */,
 				C5FE7583218BCE920090E372 /* StellarRecoveryMnemonicTests.swift in Sources */,
 				C5FE75A5218BFB090090E372 /* StellarTransactionTests.swift in Sources */,

--- a/StellarAccountService/Objects/StellarAccount.swift
+++ b/StellarAccountService/Objects/StellarAccount.swift
@@ -43,16 +43,15 @@ public final class StellarAccount {
     internal var rawResponse: AccountResponse?
 
     internal weak var service: StellarAccountService?
-    internal weak var inflationResponseDelegate: SetInflationResponseDelegate?
     internal weak var sendResponseDelegate: SendAmountResponseDelegate?
     internal weak var manageAssetResponseDelegate: ManageAssetResponseDelegate?
 
-    internal var accountQueue: OperationQueue {
+    internal lazy var accountQueue: OperationQueue = {
         let queue = OperationQueue()
         queue.qualityOfService = .userInitiated
 
         return queue
-    }
+    }()
 
     public var address: StellarAddress {
         return StellarAddress(accountId)!

--- a/StellarAccountService/Protocols.swift
+++ b/StellarAccountService/Protocols.swift
@@ -11,12 +11,37 @@ import stellarsdk
 protocol CoreService {
     var sdk: StellarSDK { get }
     var api: StellarConfig.HorizonAPI { get }
-    var secretManager: SecretManager? { get }
+    var services: [Subservice] { get }
+    var secretManager: SecretManagerProtocol? { get }
     var walletKeyPair: KeyPair? { get }
 }
 
 protocol Subservice {
     var core: CoreService { get }
+}
+
+protocol StellarAccountServiceProtocol: AnyObject, Subservice {
+    var core: CoreService { get }
+    var delegate: StellarAccountServiceDelegate? { get set }
+    var state: StellarAccountService.AccountState { get }
+    var secretManager: SecretManager? { get set }
+    var account: StellarAccount? { get set }
+}
+
+protocol StellarTradeServiceProtocol: AnyObject, Subservice {
+    var core: CoreService { get }
+    var tradeQueue: OperationQueue { get }
+}
+
+protocol SecretManagerProtocol: AnyObject {
+    var publicKeyKey: String { get }
+    var privateKeyKey: String { get }
+    var secretSeedKey: String { get }
+    var mnemonicKey: String { get }
+    var publicKey: Data? { get }
+    var privateKey: Data? { get }
+    var secretSeed: String? { get }
+    var mnemonic: String? { get }
 }
 
 // MARK: -
@@ -28,7 +53,7 @@ public protocol SendAmountResponseDelegate: AnyObject {
 // MARK: -
 public protocol SetInflationResponseDelegate: AnyObject {
     func setInflation(destination: StellarAddress)
-    func failed(error: Error)
+    func failed(error: StellarAccountService.ServiceError)
 }
 
 // MARK: -

--- a/StellarAccountService/Services/StellarAccountService.swift
+++ b/StellarAccountService/Services/StellarAccountService.swift
@@ -21,7 +21,7 @@ public protocol StellarAccountServiceDelegate: AnyObject {
  * One service object corresponds to one account, and data for each is independently managed and passed back to the app.
  *
  */
-public final class StellarAccountService: Subservice {
+public final class StellarAccountService: StellarAccountServiceProtocol {
     public enum ServiceError: Error {
         case nonExistentAccount
         case alreadyInitialized
@@ -43,11 +43,7 @@ public final class StellarAccountService: Subservice {
     let core: CoreService
 
     public weak var delegate: StellarAccountServiceDelegate?
-    public internal(set) var account: StellarAccount? {
-        didSet {
-            state = account != nil ? .active : .inactive
-        }
-    }
+    public internal(set) var account: StellarAccount?
 
     var state: AccountState = .inactive
     var secretManager: SecretManager?

--- a/StellarAccountService/Services/StellarCoreService.swift
+++ b/StellarAccountService/Services/StellarCoreService.swift
@@ -16,7 +16,7 @@ public final class StellarCoreService: CoreService {
         return [accountService, tradeService]
     }
 
-    internal var secretManager: SecretManager? {
+    internal var secretManager: SecretManagerProtocol? {
         return accountService.secretManager
     }
 

--- a/StellarAccountService/Services/StellarP2PService.swift
+++ b/StellarAccountService/Services/StellarP2PService.swift
@@ -11,12 +11,12 @@ import Foundation
 public final class StellarP2PService: Subservice {
     let core: CoreService
 
-    var tradeQueue: OperationQueue {
+    var tradeQueue: OperationQueue = {
         let queue = OperationQueue()
         queue.qualityOfService = .userInitiated
 
         return queue
-    }
+    }()
 
     internal init(with core: CoreService) {
         self.core = core

--- a/StellarAccountService/Services/StellarTradeService.swift
+++ b/StellarAccountService/Services/StellarTradeService.swift
@@ -8,7 +8,7 @@
 
 import stellarsdk
 
-public final class StellarTradeService: Subservice {
+public final class StellarTradeService: StellarTradeServiceProtocol {
     typealias PostTradeOperationPair = ChainedOperationPair<FetchAccountDataOperation, PostTradeOperation>
     typealias CancelTradeOperationPair = ChainedOperationPair<FetchAccountDataOperation, CancelTradeOperation>
 
@@ -17,12 +17,12 @@ public final class StellarTradeService: Subservice {
 
     let core: CoreService
 
-    var tradeQueue: OperationQueue {
+    lazy var tradeQueue: OperationQueue = {
         let queue = OperationQueue()
         queue.qualityOfService = .userInitiated
 
         return queue
-    }
+    }()
 
     internal init(with core: CoreService) {
         self.core = core

--- a/StellarAccountService/StellarConfig.swift
+++ b/StellarAccountService/StellarConfig.swift
@@ -12,6 +12,7 @@ public final class StellarConfig {
     internal struct HorizonHostURLs {
         static let production = "https://horizon.stellar.org"
         static let test = "https://horizon-testnet.stellar.org"
+        static let local = "localhost:3030"
     }
 
     public enum HorizonURL {
@@ -29,6 +30,7 @@ public final class StellarConfig {
     public enum HorizonAPI {
         case production
         case test
+        case local
 
         public var url: URL {
             return URL(string: self.urlString)!
@@ -38,6 +40,7 @@ public final class StellarConfig {
             switch self {
             case .production: return HorizonHostURLs.production
             case .test: return HorizonHostURLs.test
+            case .local: return HorizonHostURLs.local
             }
         }
 
@@ -45,6 +48,7 @@ public final class StellarConfig {
             switch self {
             case .production: return Network.public
             case .test: return Network.testnet
+            case .local: return Network.testnet
             }
         }
     }

--- a/StellarAccountService/Utilities/SecretManager.swift
+++ b/StellarAccountService/Utilities/SecretManager.swift
@@ -9,7 +9,7 @@
 import KeychainSwift
 import stellarsdk
 
-public final class SecretManager {
+public final class SecretManager: SecretManagerProtocol {
     static let publicSeedKeyFormat = "%@_publicKey"
     static let privateSeedKeyFormat = "%@_privateKey"
     static let secretSeedKeyFormat = "%@_secretSeed"

--- a/StellarAccountServiceTests/Objects/StellarAccountOperationTests.swift
+++ b/StellarAccountServiceTests/Objects/StellarAccountOperationTests.swift
@@ -7,13 +7,76 @@
 //
 
 import XCTest
+@testable import StellarAccountService
+import stellarsdk
 
 class StellarAccountOperationTests: XCTestCase {
+    var stubAccount: StellarAccount!
+    var service: StellarAccountService!
+
     override func setUp() {
         super.setUp()
     }
 
     override func tearDown() {
         super.tearDown()
+        self.stubAccount = nil
+        self.service = nil
+    }
+
+    func stubTestAccount() {
+        let seed = "SBCATWZ7RYZK2VY4D5RLVJQGSRLEJXM4PTAA5ZZLIQIGBGQITV6YRAKJ"
+        let stubKeyPair = try! KeyPair(secretSeed: seed)
+        self.stubAccount = StellarAccount(accountId: stubKeyPair.accountId)
+    }
+
+    func stubAccountService() {
+        let seed = "SBCATWZ7RYZK2VY4D5RLVJQGSRLEJXM4PTAA5ZZLIQIGBGQITV6YRAKJ"
+        let mnemonic = "a mnemonic for testing"
+        let stubKeyPair = try! KeyPair(secretSeed: seed)
+
+        let pubData = Data(bytes: stubKeyPair.publicKey.bytes)
+        let privData = Data(bytes: stubKeyPair.privateKey!.bytes)
+
+        let stubSecretManager = StubSecretManager(publicKey: pubData,
+                                                  privateKey: privData,
+                                                  secretSeed: seed,
+                                                  mnemonic: mnemonic)
+
+        let env = StellarConfig.HorizonAPI.local
+        let sdk = StellarSDK(withHorizonUrl: env.urlString)
+        let core = StubStellarCoreService(sdk: sdk, api: env, secretManager: stubSecretManager, keyPair: stubKeyPair)
+
+        let accountService = StellarAccountService(with: core)
+        let stubAccount = StellarAccount(accountId: stubKeyPair.accountId)
+
+        accountService.account = stubAccount
+        stubAccount.service = accountService
+
+        self.service = accountService
+        self.stubAccount = stubAccount
+    }
+
+    func testSetInflationCallsFailureWhenMissingRequiredData() {
+        self.stubTestAccount()
+        let mockDelegate = MockInflationResponseDelegate()
+        let newInflationAddress = StellarAddress("GDUFDDGP6B6VLXC2Z62UYW34VOHHQFL7PXCGWQRLWZXYNJGER3F2QRTZ")!
+        self.stubAccount.setInflationDestination(address: newInflationAddress, delegate: mockDelegate)
+        XCTAssertEqual(mockDelegate.error, StellarAccountService.ServiceError.nonExistentAccount)
+    }
+
+    func testSetInflationEnqueuesCorrectOperations() {
+        self.stubAccountService()
+
+        let queue = self.service.account!.accountQueue
+        queue.isSuspended = true
+
+        let mockDelegate = MockInflationResponseDelegate()
+        let newInflationAddress = StellarAddress("GDUFDDGP6B6VLXC2Z62UYW34VOHHQFL7PXCGWQRLWZXYNJGER3F2QRTZ")!
+        self.stubAccount.setInflationDestination(address: newInflationAddress, delegate: mockDelegate)
+
+        XCTAssertEqual(self.stubAccount.accountQueue, self.service.account!.accountQueue)
+
+        XCTAssertEqual(queue.operationCount, 3)
     }
 }

--- a/StellarAccountServiceTests/TestObjects.swift
+++ b/StellarAccountServiceTests/TestObjects.swift
@@ -1,0 +1,100 @@
+//
+//  TestObjects.swift
+//  StellarAccountServiceTests
+//
+//  Created by Nick DiZazzo on 2018-11-02.
+//  Copyright © 2018 BlockEQ. All rights reserved.
+//
+
+@testable import StellarAccountService
+import stellarsdk
+
+// MARK: - Stubs
+final class StubStellarCoreService: CoreService {
+    var sdk: StellarSDK
+
+    var api: StellarConfig.HorizonAPI
+
+    var secretManager: SecretManagerProtocol?
+
+    var walletKeyPair: KeyPair?
+
+    var services: [Subservice] {
+        return []
+    }
+
+    init(sdk: StellarSDK, api: StellarConfig.HorizonAPI, secretManager: SecretManagerProtocol?, keyPair: KeyPair) {
+        self.sdk = sdk
+        self.api = api
+        self.secretManager = secretManager
+        self.walletKeyPair = keyPair
+    }
+}
+
+final class StubStellarAccountService: StellarAccountServiceProtocol {
+    let core: CoreService
+
+    weak var delegate: StellarAccountServiceDelegate?
+
+    var state: StellarAccountService.AccountState
+
+    var secretManager: SecretManager?
+
+    var account: StellarAccount?
+
+    init(core: CoreService,
+         stubAccount: StellarAccount,
+         stubSecretManager: SecretManager,
+         delegate: StellarAccountServiceDelegate,
+         state: StellarAccountService.AccountState) {
+        self.core = core
+        self.secretManager = stubSecretManager
+        self.account = stubAccount
+        self.delegate = delegate
+        self.state = state
+    }
+}
+
+final class StubSecretManager: SecretManagerProtocol {
+    var publicKeyKey: String { return "publickeykey" }
+
+    var privateKeyKey: String { return "privatekeykey" }
+
+    var secretSeedKey: String { return "secretseedkey" }
+
+    var mnemonicKey: String { return "mnemonickey" }
+
+    var publicKey: Data?
+
+    var privateKey: Data?
+
+    var secretSeed: String?
+
+    var mnemonic: String?
+
+    init(publicKey: Data, privateKey: Data, secretSeed: String, mnemonic: String) {
+        self.publicKey = publicKey
+        self.privateKey = privateKey
+        self.secretSeed = secretSeed
+        self.mnemonic = mnemonic
+    }
+}
+
+// MARK: - Mocks
+final class MockInflationResponseDelegate: SetInflationResponseDelegate {
+    var setInflationAddress: StellarAddress?
+    var error: StellarAccountService.ServiceError?
+
+    var setInflationCompletion: ((StellarAddress) -> Void)?
+    var errorCompletion: ((StellarAccountService.ServiceError) -> Void)?
+
+    func setInflation(destination: StellarAddress) {
+        setInflationAddress = destination
+        setInflationCompletion?(destination)
+    }
+
+    func failed(error: StellarAccountService.ServiceError) {
+        self.error = error
+        self.errorCompletion?(error)
+    }
+}


### PR DESCRIPTION
## Priority
Low

## Description
This PR has some minor structural updates and adds more protocols in order to be able to write mock and stub objects within the `StellarAccountService`.

Writing mock / stub objects allows us to only test local segments of code, without having to initialize an entire set of interconnected & related objects.

## Screenshot
N/A

## Notes
* Creates TestObjects and minor refactor to make stubbing / mocking easier