### PR TITLE
[FIX] Corrects a crash when removing an asset from the users wallet

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -41,7 +41,7 @@
 		C4EC5FF120F3E64300769E31 /* AddAssetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C4EC5FEF20F3E64300769E31 /* AddAssetViewController.xib */; };
 		C4F4938A211E19EA000B0800 /* String+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F49389211E19EA000B0800 /* String+Base64.swift */; };
 		C50F390220C0AE8100DABB14 /* KeyboardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50F390120C0AE8100DABB14 /* KeyboardHelper.swift */; };
-		C512E69D217F96B300D1AC74 /* WalletSwitchingTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C512E69C217F96B300D1AC74 /* WalletSwitchingTableViewDataSource.swift */; };
+		C512E69D217F96B300D1AC74 /* WalletSwitchingDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C512E69C217F96B300D1AC74 /* WalletSwitchingDataSource.swift */; };
 		C51441F5217E5802006C44F4 /* StellarEffect+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51441F4217E5802006C44F4 /* StellarEffect+Extensions.swift */; };
 		C51441F7217E64A8006C44F4 /* StellarSeed+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51441F6217E64A8006C44F4 /* StellarSeed+Extensions.swift */; };
 		C51441F9217E7F6F006C44F4 /* StellarAsset+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51441F8217E7F6F006C44F4 /* StellarAsset+Extensions.swift */; };
@@ -257,7 +257,7 @@
 		C4EC5FEF20F3E64300769E31 /* AddAssetViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddAssetViewController.xib; sourceTree = "<group>"; };
 		C4F49389211E19EA000B0800 /* String+Base64.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Base64.swift"; sourceTree = "<group>"; };
 		C50F390120C0AE8100DABB14 /* KeyboardHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHelper.swift; sourceTree = "<group>"; };
-		C512E69C217F96B300D1AC74 /* WalletSwitchingTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwitchingTableViewDataSource.swift; sourceTree = "<group>"; };
+		C512E69C217F96B300D1AC74 /* WalletSwitchingDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwitchingDataSource.swift; sourceTree = "<group>"; };
 		C51441F4217E5802006C44F4 /* StellarEffect+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StellarEffect+Extensions.swift"; sourceTree = "<group>"; };
 		C51441F6217E64A8006C44F4 /* StellarSeed+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StellarSeed+Extensions.swift"; sourceTree = "<group>"; };
 		C51441F8217E7F6F006C44F4 /* StellarAsset+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StellarAsset+Extensions.swift"; sourceTree = "<group>"; };
@@ -491,7 +491,7 @@
 			isa = PBXGroup;
 			children = (
 				C51441FB217E839E006C44F4 /* WalletTableViewDataSource.swift */,
-				C512E69C217F96B300D1AC74 /* WalletSwitchingTableViewDataSource.swift */,
+				C512E69C217F96B300D1AC74 /* WalletSwitchingDataSource.swift */,
 				C5D8CAD02182064B009F8624 /* ContactsDataSource.swift */,
 			);
 			path = "Data Sources";
@@ -1276,7 +1276,7 @@
 				ECC47A6920589F92002BA573 /* UIView+Shake.swift in Sources */,
 				EC6EE89320B6005D0033C299 /* MyOffersViewController.swift in Sources */,
 				C53978CB20BF417100587D99 /* SettingsSwitchCell.swift in Sources */,
-				C512E69D217F96B300D1AC74 /* WalletSwitchingTableViewDataSource.swift in Sources */,
+				C512E69D217F96B300D1AC74 /* WalletSwitchingDataSource.swift in Sources */,
 				C5D1074F215D7A3E00CC17A0 /* ApplicationCoordinator+Extensions.swift in Sources */,
 				C55660492165D30C00DDAAA5 /* QRMap.swift in Sources */,
 				EC0B191E205486AB0052802C /* TransactionHistoryCell.swift in Sources */,

--- a/BlockEQ/Data Sources/WalletSwitchingDataSource.swift
+++ b/BlockEQ/Data Sources/WalletSwitchingDataSource.swift
@@ -121,6 +121,7 @@ extension WalletSwitchingDataSource: UITableViewDataSource {
             viewModel.icon = Assets.displayImage(shortCode: shortCode)
 
             walletCell.update(with: viewModel)
+            walletCell.selectionStyle = .none
 
             return walletCell
         }

--- a/BlockEQ/Data Sources/WalletTableViewDataSource.swift
+++ b/BlockEQ/Data Sources/WalletTableViewDataSource.swift
@@ -26,16 +26,19 @@ final class WalletTableViewDataSource: NSObject {
         .accountInflationDestinationUpdated
     ]
 
-    private var index: Int?
+    private var index: Int
     var effects: [StellarEffect] = []
     var account: StellarAccount
     var asset: StellarAsset? {
-        guard let index = index else { return nil }
+        if index >= account.assets.count {
+            self.index = 0
+        }
+
         return account.assets[index]
     }
 
     init(account: StellarAccount, asset: StellarAsset) {
-        self.index = account.assets.firstIndex(of: asset)
+        self.index = account.assets.firstIndex(of: asset) ?? 0
         self.account = account
         self.effects = account.effects
             .filter { $0.asset == asset && WalletTableViewDataSource.supportedEffects.contains($0.type) }

--- a/BlockEQ/View Controllers/Wallet/WalletSwitchingViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/WalletSwitchingViewController.swift
@@ -185,8 +185,10 @@ extension WalletSwitchingViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
 
-        guard let section = WalletSwitchingDataSource.Section(rawValue: indexPath.section) else { return }
-        guard let asset = dataSource?.allAssets[indexPath.row] else { return }
+        guard let section = WalletSwitchingDataSource.Section(rawValue: indexPath.section),
+            section == .userAssets, let asset = dataSource?.allAssets[indexPath.row] else {
+                return
+        }
 
         switch section {
         case WalletSwitchingDataSource.Section.userAssets:
@@ -205,6 +207,11 @@ extension WalletSwitchingViewController: WalletDataSourceDelegate {
 
     func remove(_ dataSource: WalletSwitchingDataSource, asset: StellarAsset) {
         displayRemovePrompt()
+
+        if let nativeAsset = dataSource.allAssets.first {
+            delegate?.switchWallet(to: nativeAsset)
+        }
+
         delegate?.remove(asset: asset)
     }
 


### PR DESCRIPTION
## Priority
High

## Description
This PR fixes a crash that occurs when removing the asset that the wallet is currently switched to. It now does an out-of-bounds check, and also switches the wallet back to the native asset when this case occurs.

## Screenshot
N/A

## Notes
* Remove optional index
* Make native asset selected when removing currently selected asset