### PR TITLE
[FIX] Trade selectors not being populated after adding asset in trade view

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -45,7 +45,7 @@
 		C51441F5217E5802006C44F4 /* StellarEffect+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51441F4217E5802006C44F4 /* StellarEffect+Extensions.swift */; };
 		C51441F7217E64A8006C44F4 /* StellarSeed+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51441F6217E64A8006C44F4 /* StellarSeed+Extensions.swift */; };
 		C51441F9217E7F6F006C44F4 /* StellarAsset+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51441F8217E7F6F006C44F4 /* StellarAsset+Extensions.swift */; };
-		C51441FC217E839E006C44F4 /* WalletTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51441FB217E839E006C44F4 /* WalletTableViewDataSource.swift */; };
+		C51441FC217E839E006C44F4 /* WalletDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51441FB217E839E006C44F4 /* WalletDataSource.swift */; };
 		C514420B217EC25A006C44F4 /* StellarAccountService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C514420A217EC25A006C44F4 /* StellarAccountService.framework */; };
 		C514420C217EC25A006C44F4 /* StellarAccountService.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C514420A217EC25A006C44F4 /* StellarAccountService.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C514420E217ED2B7006C44F4 /* StellarTransaction+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C514420D217ED2B7006C44F4 /* StellarTransaction+Extensions.swift */; };
@@ -92,6 +92,7 @@
 		C5AB41392090430900096A29 /* UICollectionView+ReusableCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AB41382090430900096A29 /* UICollectionView+ReusableCells.swift */; };
 		C5AB413B2090433000096A29 /* UIView+ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AB413A2090433000096A29 /* UIView+ReusableView.swift */; };
 		C5AB413D2090436700096A29 /* UIView+NibLoadableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AB413C2090436700096A29 /* UIView+NibLoadableView.swift */; };
+		C5ADFFCF2190C8CC004EA646 /* TradePickerDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ADFFCE2190C8CC004EA646 /* TradePickerDataSource.swift */; };
 		C5AF7C8A2094B60A00F99835 /* UIImage+CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AF7C892094B60A00F99835 /* UIImage+CALayer.swift */; };
 		C5BB02492165269F00E4AAD1 /* SecretSeedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C5BB02482165269F00E4AAD1 /* SecretSeedViewController.xib */; };
 		C5BB024B2165274200E4AAD1 /* SecretSeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5BB024A2165274200E4AAD1 /* SecretSeedViewController.swift */; };
@@ -261,7 +262,7 @@
 		C51441F4217E5802006C44F4 /* StellarEffect+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StellarEffect+Extensions.swift"; sourceTree = "<group>"; };
 		C51441F6217E64A8006C44F4 /* StellarSeed+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StellarSeed+Extensions.swift"; sourceTree = "<group>"; };
 		C51441F8217E7F6F006C44F4 /* StellarAsset+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StellarAsset+Extensions.swift"; sourceTree = "<group>"; };
-		C51441FB217E839E006C44F4 /* WalletTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTableViewDataSource.swift; sourceTree = "<group>"; };
+		C51441FB217E839E006C44F4 /* WalletDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletDataSource.swift; sourceTree = "<group>"; };
 		C5144208217EC233006C44F4 /* StellarAccountService.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StellarAccountService.framework; path = "../../../Library/Developer/Xcode/DerivedData/BlockEQ-gwrkvoohihdsfeakhajltsjvevfp/Build/Products/Debug-iphoneos/StellarAccountService.framework"; sourceTree = "<group>"; };
 		C514420A217EC25A006C44F4 /* StellarAccountService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StellarAccountService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C514420D217ED2B7006C44F4 /* StellarTransaction+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StellarTransaction+Extensions.swift"; sourceTree = "<group>"; };
@@ -310,6 +311,7 @@
 		C5AB41382090430900096A29 /* UICollectionView+ReusableCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+ReusableCells.swift"; sourceTree = "<group>"; };
 		C5AB413A2090433000096A29 /* UIView+ReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ReusableView.swift"; sourceTree = "<group>"; };
 		C5AB413C2090436700096A29 /* UIView+NibLoadableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+NibLoadableView.swift"; sourceTree = "<group>"; };
+		C5ADFFCE2190C8CC004EA646 /* TradePickerDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TradePickerDataSource.swift; sourceTree = "<group>"; };
 		C5AF7C892094B60A00F99835 /* UIImage+CALayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+CALayer.swift"; sourceTree = "<group>"; };
 		C5BB02482165269F00E4AAD1 /* SecretSeedViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SecretSeedViewController.xib; sourceTree = "<group>"; };
 		C5BB024A2165274200E4AAD1 /* SecretSeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretSeedViewController.swift; sourceTree = "<group>"; };
@@ -490,9 +492,10 @@
 		C51441FA217E836A006C44F4 /* Data Sources */ = {
 			isa = PBXGroup;
 			children = (
-				C51441FB217E839E006C44F4 /* WalletTableViewDataSource.swift */,
+				C51441FB217E839E006C44F4 /* WalletDataSource.swift */,
 				C512E69C217F96B300D1AC74 /* WalletSwitchingDataSource.swift */,
 				C5D8CAD02182064B009F8624 /* ContactsDataSource.swift */,
+				C5ADFFCE2190C8CC004EA646 /* TradePickerDataSource.swift */,
 			);
 			path = "Data Sources";
 			sourceTree = "<group>";
@@ -1218,7 +1221,7 @@
 				C5401D342178005B00A12AC2 /* TransactionDetailsViewController.swift in Sources */,
 				EC2015F720532F4B009A73C8 /* AppButton.swift in Sources */,
 				C5AB413D2090436700096A29 /* UIView+NibLoadableView.swift in Sources */,
-				C51441FC217E839E006C44F4 /* WalletTableViewDataSource.swift in Sources */,
+				C51441FC217E839E006C44F4 /* WalletDataSource.swift in Sources */,
 				EC20160120536C68009A73C8 /* PillView.swift in Sources */,
 				ECB1D958207E966D0088826D /* MBProgressHUD.m in Sources */,
 				C54EFE4A21798668005FA6D3 /* UIView+Layer.swift in Sources */,
@@ -1246,6 +1249,7 @@
 				C439A22B211B6F9C0025C047 /* CreateTokenViewController.swift in Sources */,
 				EC1CEE5320577E880005F74E /* WordSuggestionCell.swift in Sources */,
 				C41165152123B7CB00C4CB6E /* ContactsViewController.swift in Sources */,
+				C5ADFFCF2190C8CC004EA646 /* TradePickerDataSource.swift in Sources */,
 				EC42584B2054E346000941B5 /* SendViewController.swift in Sources */,
 				EC52B3C920BB746C006299A1 /* OrderBookHeaderView.swift in Sources */,
 				C593C46E2092E51A00D6047F /* NavigationCell.swift in Sources */,

--- a/BlockEQ/Coordinators/TradingCoordinator.swift
+++ b/BlockEQ/Coordinators/TradingCoordinator.swift
@@ -219,6 +219,7 @@ extension TradingCoordinator: ManageAssetResponseDelegate {
     func added(asset: StellarAsset, account: StellarAccount) {
         self.segmentController.updated(account: account)
         self.walletSwitchingViewController?.updateMenu(account: account)
+        self.tradeViewController.update(account: account)
     }
 
     func removed(asset: StellarAsset, account: StellarAccount) {

--- a/BlockEQ/Data Sources/TradePickerDataSource.swift
+++ b/BlockEQ/Data Sources/TradePickerDataSource.swift
@@ -1,0 +1,52 @@
+//
+//  TradePickerDataSource.swift
+//  BlockEQ
+//
+//  Created by Nick DiZazzo on 2018-11-05.
+//  Copyright © 2018 BlockEQ. All rights reserved.
+//
+
+import StellarAccountService
+
+protocol TradePickerDataSourceDelegate: AnyObject {
+    func selectedAsset(_ pickerView: UIPickerView, asset: StellarAsset?)
+}
+
+final class TradePickerDataSource: NSObject {
+    var selected: StellarAsset?
+    var excludingAsset: StellarAsset?
+    var assets: [StellarAsset] = []
+    weak var delegate: TradePickerDataSourceDelegate?
+
+    init(assets: [StellarAsset], selected: StellarAsset?, excluding: StellarAsset?) {
+        self.assets = assets.filter { $0 != excluding }
+        self.selected = selected
+        self.excludingAsset = excluding
+    }
+}
+
+// MARK: - UIPickerViewDataSource
+extension TradePickerDataSource: UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return assets.count
+    }
+
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        let asset = assets[row]
+        delegate?.selectedAsset(pickerView, asset: asset)
+    }
+}
+
+// MARK: - UIPickerViewDelegate
+extension TradePickerDataSource: UIPickerViewDelegate {
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        let asset = assets[row]
+        return String(format: "TRADE_PICKER_FORMAT_STRING".localized(),
+                      Assets.displayTitle(shortCode: asset.shortCode),
+                      asset.shortCode)
+    }
+}

--- a/BlockEQ/Data Sources/WalletDataSource.swift
+++ b/BlockEQ/Data Sources/WalletDataSource.swift
@@ -9,7 +9,7 @@
 import StellarAccountService
 import stellarsdk
 
-final class WalletTableViewDataSource: NSObject {
+final class WalletDataSource: NSObject {
     enum Section: Int, RawRepresentable {
         case assetHeader
         case effectList
@@ -41,12 +41,12 @@ final class WalletTableViewDataSource: NSObject {
         self.index = account.assets.firstIndex(of: asset) ?? 0
         self.account = account
         self.effects = account.effects
-            .filter { $0.asset == asset && WalletTableViewDataSource.supportedEffects.contains($0.type) }
+            .filter { $0.asset == asset && WalletDataSource.supportedEffects.contains($0.type) }
             .sorted(by: { (first, second) -> Bool in first.createdAt > second.createdAt })
     }
 }
 
-extension WalletTableViewDataSource: UITableViewDataSource {
+extension WalletDataSource: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
         return Section.all.count
     }

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -168,3 +168,4 @@
 "INFLATION_DESTINATION_INVALID" = "Unable to update the inflation destination to your own account, or the account it's already set to.";
 "CRYPTO_DUST_FORMAT_STRING" = "< %@";
 "AVAILABLE_BALANCE_FORMAT_STRING" = "Available: %@ %@";
+"TRADE_PICKER_FORMAT_STRING" = "%@ (%@)";

--- a/BlockEQ/View Controllers/Trade/OrderBookViewController.swift
+++ b/BlockEQ/View Controllers/Trade/OrderBookViewController.swift
@@ -35,6 +35,11 @@ class OrderBookViewController: UIViewController {
         setupView()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        refreshView()
+    }
+
     func setupView() {
         tableView.registerCell(type: OrderBookCell.self)
         tableView.registerCell(type: OrderBookEmptyCell.self)
@@ -44,12 +49,15 @@ class OrderBookViewController: UIViewController {
         tableHeaderView.backgroundColor = Colors.white
     }
 
+    func refreshView() {
+        guard isViewLoaded else { return }
+        tableHeaderLabel.text = "\(sellAsset.shortCode) - \(buyAsset.shortCode)"
+        tableView.reloadData()
+    }
+
     func setOrderBook(orderbook: StellarOrderbook) {
         self.orderbook = orderbook
-
-        tableHeaderLabel.text = "\(sellAsset.shortCode) - \(buyAsset.shortCode)"
-
-        tableView.reloadData()
+        refreshView()
     }
 }
 

--- a/BlockEQ/View Controllers/Trade/TradeSegmentViewController.swift
+++ b/BlockEQ/View Controllers/Trade/TradeSegmentViewController.swift
@@ -48,16 +48,22 @@ final class TradeSegmentViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if displayNoAssetOverlay {
-            displayNoAssetOverlayView()
-        } else {
-            hideNoAssetOverlayView()
-        }
+        self.refreshView()
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setupView()
+    }
+
+    func refreshView() {
+        guard self.isViewLoaded else { return }
+
+        if displayNoAssetOverlay {
+            displayNoAssetOverlayView()
+        } else {
+            hideNoAssetOverlayView()
+        }
     }
 
     func setupView() {
@@ -110,6 +116,8 @@ final class TradeSegmentViewController: UIViewController {
 
     func updated(account: StellarAccount) {
         displayNoAssetOverlay = account.assets.count <= 1 ? true : false
+
+        self.refreshView()
     }
 }
 

--- a/BlockEQ/View Controllers/Wallet/WalletViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/WalletViewController.swift
@@ -36,7 +36,7 @@ class WalletViewController: UIViewController {
 
     weak var delegate: WalletViewControllerDelegate?
     var navigationContainer: AppNavigationController?
-    var dataSource: WalletTableViewDataSource?
+    var dataSource: WalletDataSource?
     var showNativeHeader: Bool = false
 
     override func viewDidLoad() {
@@ -108,7 +108,7 @@ class WalletViewController: UIViewController {
     }
 
     func update(with account: StellarAccount, asset: StellarAsset) {
-        dataSource = WalletTableViewDataSource(account: account, asset: asset)
+        dataSource = WalletDataSource(account: account, asset: asset)
 
         guard self.isViewLoaded else { return }
 
@@ -142,7 +142,7 @@ extension WalletViewController: AccountUpdatable {
 
 extension WalletViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let section = WalletTableViewDataSource.Section(rawValue: section) else { return nil }
+        guard let section = WalletDataSource.Section(rawValue: section) else { return nil }
 
         switch section {
         case .assetHeader: return showNativeHeader ? availableBalanceView : nil
@@ -154,7 +154,7 @@ extension WalletViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard let section = WalletTableViewDataSource.Section(rawValue: section) else { return 0 }
+        guard let section = WalletDataSource.Section(rawValue: section) else { return 0 }
 
         switch section {
         case .assetHeader: return showNativeHeader ? availableBalanceView.frame.size.height : 0

--- a/StellarAccountService/Objects/StellarAccount.swift
+++ b/StellarAccountService/Objects/StellarAccount.swift
@@ -77,6 +77,12 @@ public final class StellarAccount {
         return Array(mappedOffers.values)
     }
 
+    public var indexedAssets: [String: StellarAsset] {
+        return assets.reduce(into: [:], { list, asset in
+            list[asset.shortCode] = asset
+        })
+    }
+
     public init(_ response: AccountResponse) {
         self.accountId = response.accountId
         self.inflationDestination = response.inflationDestination

--- a/StellarAccountServiceTests/Objects/StellarAccountTests.swift
+++ b/StellarAccountServiceTests/Objects/StellarAccountTests.swift
@@ -40,6 +40,16 @@ class StellarAccountTests: XCTestCase {
         XCTAssertEqual(stubAccount.inflationAddress, StellarAddress("GCCD6AJOYZCUAQLX32ZJF2MKFFAUJ53PVCFQI3RHWKL3V47QYE2BNAUT"))
     }
 
+    func testIndexedAssetsReturnsCorrectValues() {
+        let response: AccountResponse = JSONLoader.decodableJSON(name: "account_response")
+        let account = StellarAccount(response)
+
+        XCTAssertEqual(account.indexedAssets.count, account.assets.count)
+        XCTAssertEqual(account.indexedAssets["XLM"], StellarAsset.lumens)
+        XCTAssertEqual(account.indexedAssets["CAD"], StellarAsset(assetCode: "CAD", issuer: "GABK2IHWW7BCRPP3BL6WMOMDBPHCBJR2SLP5HAUBYKNZG5J5RJSROS5S"))
+        XCTAssertEqual(account.indexedAssets["PTS"], StellarAsset(assetCode: "PTS", issuer: "GBPG7KRYC3PTKHBXQGRD3GMZ5DB4C3D553ZN2ZLH57LBAQIULVY46Z5F"))
+    }
+
     func testResponseInitializer() {
         let response: AccountResponse = JSONLoader.decodableJSON(name: "account_response")
         let account = StellarAccount(response)


### PR DESCRIPTION
## Priority
Normal

## Description
This PR updates the trade selectors in the `TradeViewController` to use data sources for each picker. 

This allows us to refresh them more consistently in order to fix a bug when adding an asset in the `TradeViewController` when no assets other than lumens are available on the user's account.

## Screenshot
![fixed](https://user-images.githubusercontent.com/728690/48040374-a19a3b80-e146-11e8-8b54-4f2d3ffc7de4.gif)
