### PR TITLE
[FIX] Missing fields / translations in TransactionDetailsCell

### DIFF
--- a/BlockEQ/Coordinators/ApplicationCoordinator+Extensions.swift
+++ b/BlockEQ/Coordinators/ApplicationCoordinator+Extensions.swift
@@ -108,7 +108,7 @@ extension ApplicationCoordinator: WalletViewControllerDelegate {
                 operations = accountOperations.filter { $0.transactionHash == transaction.hash }
             }
 
-            transactionVC.update(with: transaction, operations)
+            transactionVC.update(with: transaction, operations, effect)
             wrappingNavController?.pushViewController(transactionVC, animated: true)
         }
     }

--- a/BlockEQ/Data Sources/TransactionDetailsDataSource.swift
+++ b/BlockEQ/Data Sources/TransactionDetailsDataSource.swift
@@ -33,13 +33,16 @@ final class TransactionDetailsDataSource: NSObject {
     let operations: [StellarOperation]
     let signers: [String]
 
-    init(delegate: TransactionDetailsViewController, transaction: StellarTransaction, ops: [StellarOperation]) {
+    init(delegate: TransactionDetailsViewController,
+         transaction: StellarTransaction,
+         ops: [StellarOperation],
+         effect: StellarEffect) {
         headerDelegate = delegate
         ledgerHeaderText = String(transaction.ledger)
         signers = transaction.signatures
         sourceAccount = transaction.sourceAccount
         txid = transaction.identifier
-        amount = "---"
+        amount = effect.amount.isEmpty ? "---" : effect.amount
         date = transaction.createdAt
         sequenceNumber = transaction.sequenceNumber
         fee = transaction.feePaid
@@ -80,14 +83,14 @@ extension TransactionDetailsDataSource: UICollectionViewDataSource {
         var memoString = ""
 
         if let unwrappedMemo = memo?.string, let type = memoType {
-            memoTitle = String(format: "MEMO_TITLE_FORMAT_STRING", type)
+            memoTitle = String(format: "MEMO_TITLE_FORMAT_STRING".localized(), type)
             memoString = unwrappedMemo
         }
 
         let viewModel = TransactionDetailsCell.ViewModel(
             sourceAccount: sourceAccount,
             transactionId: txid,
-            amount: "---",
+            amount: amount,
             date: date.longDateString,
             sequenceNumber: sequenceNumber,
             fee: String(format: "XLM_FORMAT_STRING".localized(), stroopFee.tradeFormattedString),

--- a/BlockEQ/View Controllers/Transactions/TransactionDetailsViewController.swift
+++ b/BlockEQ/View Controllers/Transactions/TransactionDetailsViewController.swift
@@ -47,8 +47,11 @@ final class TransactionDetailsViewController: UIViewController {
         collectionView.backgroundColor = backgroundColor
     }
 
-    func update(with data: StellarTransaction, _ operations: [StellarOperation]) {
-        let transactionDataSource = TransactionDetailsDataSource(delegate: self, transaction: data, ops: operations)
+    func update(with data: StellarTransaction, _ operations: [StellarOperation], _ effect: StellarEffect) {
+        let transactionDataSource = TransactionDetailsDataSource(delegate: self,
+                                                                 transaction: data,
+                                                                 ops: operations,
+                                                                 effect: effect)
         dataSource = transactionDataSource
     }
 }
@@ -78,7 +81,7 @@ extension TransactionDetailsViewController: UICollectionViewDelegate {
 
         if copyString != nil {
             UIPasteboard.general.string = copyString
-            UIAlertController.simpleAlert(title: titleString, message: nil, presentingViewController: self)
+            UIAlertController.simpleAlert(title: titleString, message: copyString, presentingViewController: self)
         }
     }
 

--- a/BlockEQ/Views/Transactions/TransactionDetailsCell.swift
+++ b/BlockEQ/Views/Transactions/TransactionDetailsCell.swift
@@ -40,6 +40,7 @@ final class TransactionDetailsCell: UICollectionViewCell, ReusableView, NibLoada
     @IBOutlet weak var memoTitleLabel: UILabel!
     @IBOutlet weak var memoLabel: UILabel!
     @IBOutlet weak var transactionDetailsContainerView: UIView!
+    @IBOutlet weak var dataStackView: UIStackView!
 
     static let cellHeight = CGFloat(325.0)
 
@@ -101,9 +102,6 @@ final class TransactionDetailsCell: UICollectionViewCell, ReusableView, NibLoada
 
         transactionDetailsContainerView.topBorder(with: Colors.transactionCellBorderGray, width: 1)
         transactionDetailsContainerView.bottomBorder(with: Colors.transactionCellBorderGray, width: 1)
-    }
-
-    @IBAction func copySelected(_ sender: Any) {
     }
 
     func update(with viewModel: ViewModel) {

--- a/BlockEQ/Views/Transactions/TransactionDetailsCell.xib
+++ b/BlockEQ/Views/Transactions/TransactionDetailsCell.xib
@@ -344,6 +344,7 @@
                 <outlet property="amountLabel" destination="2RG-9z-nx6" id="5yX-HJ-asq"/>
                 <outlet property="amountTitleLabel" destination="15A-TS-NZz" id="SXA-Mk-EDE"/>
                 <outlet property="bgView" destination="hP3-Dq-43N" id="k0a-0V-meY"/>
+                <outlet property="dataStackView" destination="Ggq-eo-n4F" id="GHq-64-QLn"/>
                 <outlet property="dateLabel" destination="wEr-Pw-0fI" id="qNw-6f-aAe"/>
                 <outlet property="dateTitleLabel" destination="YSl-oW-jgG" id="QHK-GE-bjf"/>
                 <outlet property="feeLabel" destination="QRv-5S-4a9" id="hin-g6-Lis"/>


### PR DESCRIPTION
## Priority
Normal

## Description
This PR corrects a missing translation for a format string on the memo field, updates the copy data messaging, and integrates the amount for each effect into the `TransactionDetailsCell`

## Screenshot
<img width="514" alt="screenshot 2018-11-10 12 28 00" src="https://user-images.githubusercontent.com/728690/48304215-20df9480-e4e4-11e8-9f39-a298f7c4b9e2.png">
