### PR TITLE
[FIX] Adds app diagnostics, and makes battery state an optional field

### DIFF
--- a/BlockEQ/Coordinators/OnboardingCoordinator.swift
+++ b/BlockEQ/Coordinators/OnboardingCoordinator.swift
@@ -87,7 +87,7 @@ extension OnboardingCoordinator: MnemonicViewControllerDelegate {
 
 extension OnboardingCoordinator: VerificationViewControllerDelegate {
     func validatedAccount(_ viewController: VerificationViewController, mnemonic: StellarRecoveryMnemonic) {
-        save(mnemonic: mnemonic, recovered: false, passphrase: false)
+        save(mnemonic: mnemonic, recovered: true, passphrase: false)
         authenticate()
     }
 

--- a/BlockEQ/Extensions/UIView+Autolayout.swift
+++ b/BlockEQ/Extensions/UIView+Autolayout.swift
@@ -87,4 +87,17 @@ public extension UIView {
         }
         return constraint
     }
+
+    func forceLayout(width: CGFloat) {
+        var frame = self.frame
+        frame.size.width = width
+        self.frame = frame
+
+        self.setNeedsLayout()
+        self.layoutIfNeeded()
+
+        let height = self.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+        frame.size.height = height
+        self.frame = frame
+    }
 }

--- a/BlockEQ/Objects/Diagnostic+Extensions.swift
+++ b/BlockEQ/Objects/Diagnostic+Extensions.swift
@@ -13,9 +13,9 @@ extension WalletDiagnostic.CreationMethod {
         var creationMethod: WalletDiagnostic.CreationMethod = .unknown
 
         if recovered {
-            creationMethod = mnemonic.type == .twelve ? .recoveredMnemonic12 : .recoveredMnemonic24
+            creationMethod = mnemonic.type == .twelve ? .recoveredMnemonic12 : .recoveredMnemonic12
         } else {
-            creationMethod = mnemonic.type == .twentyFour ? .createdMnemonic12 : .createdMnemonic24
+            creationMethod = mnemonic.type == .twentyFour ? .createdMnemonic24 : .createdMnemonic24
         }
 
         return creationMethod

--- a/BlockEQ/Objects/Diagnostic.swift
+++ b/BlockEQ/Objects/Diagnostic.swift
@@ -28,10 +28,12 @@ struct Diagnostic {
     init(email: String, issue: String) {
         issueSummary = issue
         emailAddress = email
+        self.appDiagnostic = AppDiagnostic()
     }
 
     init(walletDiagnostic: WalletDiagnostic?) {
         self.walletDiagnostic = walletDiagnostic
+        self.appDiagnostic = AppDiagnostic()
     }
 
     init(email: String, issue: String, walletDiagnostic: WalletDiagnostic) {
@@ -119,9 +121,9 @@ struct AppDiagnostic {
         return "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
     }
 
-    var batteryState: String {
+    var batteryState: String? {
         switch UIDevice.current.batteryState {
-        case .unknown: return "Unknown"
+        case .unknown: return nil
         default: return "\(UIDevice.current.batteryState.stateString) - \(UIDevice.current.batteryLevel * 100.0)%"
         }
     }

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -182,8 +182,8 @@
 "WALLET_DIAGNOSTICS_TITLE" = "Wallet Diagnostics";
 "ADDITIONAL_INFORMATION_TITLE" = "Additional Information";
 "DIAGNOSTIC_COMPLETE_TITLE" = "Diagnostic Complete";
-"WALLET_DIAGNOSTICS_DESCRIPTION" = "This tool collects non-private information about your wallet in order to help diagnose issues with your wallet during a support request.";
-"ADDITIONAL_INFORMATION_DESCRIPTION" = "We need some additional information in order to help you.\n\nPlease enter the mandatory fields below.";
+"WALLET_DIAGNOSTICS_DESCRIPTION" = "This tool collects non-private information about your wallet in order to help diagnose issues.";
+"ADDITIONAL_INFORMATION_DESCRIPTION" = "We need some additional information in order to help you.";
 "DIAGNOSTIC_COMPLETE_DESCRIPTION" = "When you contact BlockEQ for support, refer to your diagnostic ID below.";
 "DIAGNOSTIC_ID_TITLE" = "Diagnostic ID";
 "DIAGNOSTIC_DATA_TITLE" = "Diagnostic Data";

--- a/BlockEQ/View Controllers/Diagnostics/DiagnosticViewController.swift
+++ b/BlockEQ/View Controllers/Diagnostics/DiagnosticViewController.swift
@@ -64,6 +64,10 @@ final class DiagnosticViewController: UIViewController {
         layout?.scrollDirection = .horizontal
         layout?.minimumLineSpacing = DiagnosticViewController.cellSpacing
         layout?.minimumInteritemSpacing = DiagnosticViewController.cellSpacing
+        layout?.estimatedItemSize = CGSize(width: stepCollectionView.frame.width, height: 200)
+
+        titleLabel?.text = DiagnosticCoordinator.DiagnosticStep.summary.title
+        descriptionLabel?.text = DiagnosticCoordinator.DiagnosticStep.summary.description
     }
 
     func scrollTo(step: DiagnosticCoordinator.DiagnosticStep, animated: Bool) {
@@ -121,15 +125,6 @@ extension DiagnosticViewController: UICollectionViewDelegate {
 }
 
 extension DiagnosticViewController: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView,
-                        layout collectionViewLayout: UICollectionViewLayout,
-                        sizeForItemAt indexPath: IndexPath) -> CGSize {
-
-        let cellWidth = collectionView.frame.width - DiagnosticViewController.cellSpacing * 2
-        let cellHeight = collectionView.frame.height
-        return CGSize(width: cellWidth, height: cellHeight)
-    }
-
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         insetForSectionAt section: Int) -> UIEdgeInsets {

--- a/BlockEQ/Views/Cells/Diagnostics/DiagnosticCompletedCell.swift
+++ b/BlockEQ/Views/Cells/Diagnostics/DiagnosticCompletedCell.swift
@@ -11,6 +11,7 @@ final class DiagnosticCompletedCell: UICollectionViewCell, ReusableView, NibLoad
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var diagnosticIdLabel: UILabel!
+    @IBOutlet weak var cellWidthConstraint: NSLayoutConstraint!
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -28,6 +29,8 @@ final class DiagnosticCompletedCell: UICollectionViewCell, ReusableView, NibLoad
     }
 
     func setupStyle() {
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        
         contentView.backgroundColor = Colors.transparent
         backgroundView?.backgroundColor = Colors.transparent
         containerView.backgroundColor = Colors.white

--- a/BlockEQ/Views/Cells/Diagnostics/DiagnosticCompletedCell.xib
+++ b/BlockEQ/Views/Cells/Diagnostics/DiagnosticCompletedCell.xib
@@ -12,60 +12,69 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="luI-Dm-wkX" userLabel="Content View" customClass="DiagnosticCompletedCell" customModule="BlockEQ" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="35R-1t-QmC" customClass="DiagnosticCompletedCell" customModule="BlockEQ" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="315" height="331"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bBE-x9-BAX" userLabel="Container View">
-                    <rect key="frame" x="0.0" y="20" width="375" height="647"/>
-                    <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Diagnostic ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mca-Np-VC3">
-                            <rect key="frame" x="136.5" y="25" width="102" height="20.5"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-check" translatesAutoresizingMaskIntoConstraints="NO" id="2dh-7C-4aS">
-                            <rect key="frame" x="123.5" y="259.5" width="128" height="128"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="128" id="MFz-XM-kVX"/>
-                                <constraint firstAttribute="width" constant="128" id="Oj2-J1-Lcd"/>
-                            </constraints>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="AEF1BC" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YfH-dv-4AQ">
-                            <rect key="frame" x="157" y="601.5" width="61" height="20.5"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstItem="2dh-7C-4aS" firstAttribute="centerX" secondItem="bBE-x9-BAX" secondAttribute="centerX" id="0Q3-He-bWm"/>
-                        <constraint firstAttribute="bottom" secondItem="YfH-dv-4AQ" secondAttribute="bottom" constant="25" id="Ic4-0j-O5W"/>
-                        <constraint firstItem="YfH-dv-4AQ" firstAttribute="centerX" secondItem="2dh-7C-4aS" secondAttribute="centerX" id="Q2d-Jx-s4e"/>
-                        <constraint firstItem="Mca-Np-VC3" firstAttribute="centerX" secondItem="2dh-7C-4aS" secondAttribute="centerX" id="XAt-K4-e8A"/>
-                        <constraint firstItem="2dh-7C-4aS" firstAttribute="centerY" secondItem="bBE-x9-BAX" secondAttribute="centerY" id="hk6-Oa-Ram"/>
-                        <constraint firstItem="Mca-Np-VC3" firstAttribute="top" secondItem="bBE-x9-BAX" secondAttribute="top" constant="25" id="zGJ-rc-3nU"/>
-                    </constraints>
-                </view>
-            </subviews>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
+                <rect key="frame" x="0.0" y="0.0" width="315" height="331"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bBE-x9-BAX" userLabel="Container View">
+                        <rect key="frame" x="0.0" y="0.0" width="315" height="331"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Diagnostic ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mca-Np-VC3">
+                                <rect key="frame" x="106.5" y="25" width="102" height="26.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-check" translatesAutoresizingMaskIntoConstraints="NO" id="2dh-7C-4aS">
+                                <rect key="frame" x="93.5" y="101.5" width="128" height="128"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="128" id="MFz-XM-kVX"/>
+                                    <constraint firstAttribute="width" constant="128" id="Oj2-J1-Lcd"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="AEF1BC" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YfH-dv-4AQ">
+                                <rect key="frame" x="127" y="279.5" width="61" height="26.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="2dh-7C-4aS" firstAttribute="centerX" secondItem="bBE-x9-BAX" secondAttribute="centerX" id="0Q3-He-bWm"/>
+                            <constraint firstItem="2dh-7C-4aS" firstAttribute="top" secondItem="Mca-Np-VC3" secondAttribute="bottom" constant="50" id="2kB-UC-TaY"/>
+                            <constraint firstItem="YfH-dv-4AQ" firstAttribute="top" secondItem="2dh-7C-4aS" secondAttribute="bottom" constant="50" id="7eh-4o-17J"/>
+                            <constraint firstAttribute="bottom" secondItem="YfH-dv-4AQ" secondAttribute="bottom" constant="25" id="Ic4-0j-O5W"/>
+                            <constraint firstAttribute="width" constant="315" id="Oil-2D-0Fl"/>
+                            <constraint firstItem="YfH-dv-4AQ" firstAttribute="centerX" secondItem="2dh-7C-4aS" secondAttribute="centerX" id="Q2d-Jx-s4e"/>
+                            <constraint firstItem="Mca-Np-VC3" firstAttribute="centerX" secondItem="2dh-7C-4aS" secondAttribute="centerX" id="XAt-K4-e8A"/>
+                            <constraint firstItem="2dh-7C-4aS" firstAttribute="centerY" secondItem="bBE-x9-BAX" secondAttribute="centerY" id="hk6-Oa-Ram"/>
+                            <constraint firstItem="Mca-Np-VC3" firstAttribute="top" secondItem="bBE-x9-BAX" secondAttribute="top" constant="25" id="zGJ-rc-3nU"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="3SQ-sJ-rG6"/>
+                    </view>
+                </subviews>
+            </view>
             <constraints>
-                <constraint firstItem="yh8-h2-E91" firstAttribute="bottom" secondItem="bBE-x9-BAX" secondAttribute="bottom" id="6ed-AN-g90"/>
-                <constraint firstItem="bBE-x9-BAX" firstAttribute="leading" secondItem="yh8-h2-E91" secondAttribute="leading" id="6hA-Ws-4QQ"/>
-                <constraint firstItem="bBE-x9-BAX" firstAttribute="top" secondItem="yh8-h2-E91" secondAttribute="top" id="Ez7-Hg-pEU"/>
-                <constraint firstItem="yh8-h2-E91" firstAttribute="trailing" secondItem="bBE-x9-BAX" secondAttribute="trailing" id="NFk-ge-OSN"/>
+                <constraint firstAttribute="trailing" secondItem="bBE-x9-BAX" secondAttribute="trailing" id="RJH-M1-Ipn"/>
+                <constraint firstItem="bBE-x9-BAX" firstAttribute="top" secondItem="35R-1t-QmC" secondAttribute="top" id="hO1-Qt-XlJ"/>
+                <constraint firstAttribute="bottom" secondItem="bBE-x9-BAX" secondAttribute="bottom" id="ijZ-uK-UdD"/>
+                <constraint firstItem="bBE-x9-BAX" firstAttribute="leading" secondItem="35R-1t-QmC" secondAttribute="leading" id="pvd-3g-zVL"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="yh8-h2-E91"/>
+            <viewLayoutGuide key="safeArea" id="K9f-eG-11N"/>
+            <size key="customSize" width="315" height="331"/>
             <connections>
-                <outlet property="containerView" destination="bBE-x9-BAX" id="Qbk-Oj-TQt"/>
-                <outlet property="diagnosticIdLabel" destination="YfH-dv-4AQ" id="Ego-Gh-HyM"/>
-                <outlet property="imageView" destination="2dh-7C-4aS" id="kqN-bU-NV3"/>
-                <outlet property="titleLabel" destination="Mca-Np-VC3" id="Qx5-Jz-4NW"/>
+                <outlet property="cellWidthConstraint" destination="Oil-2D-0Fl" id="bcq-JP-Fad"/>
+                <outlet property="containerView" destination="bBE-x9-BAX" id="umg-kJ-JMz"/>
+                <outlet property="diagnosticIdLabel" destination="YfH-dv-4AQ" id="Oc9-vz-9uW"/>
+                <outlet property="imageView" destination="2dh-7C-4aS" id="U35-Eo-5oD"/>
+                <outlet property="titleLabel" destination="Mca-Np-VC3" id="ELR-u0-nPW"/>
             </connections>
-            <point key="canvasLocation" x="748" y="711.99400299850083"/>
-        </view>
+            <point key="canvasLocation" x="349.60000000000002" y="194.75262368815595"/>
+        </collectionViewCell>
     </objects>
     <resources>
         <image name="icon-check" width="128" height="128"/>

--- a/BlockEQ/Views/Cells/Diagnostics/DiagnosticDataCell.swift
+++ b/BlockEQ/Views/Cells/Diagnostics/DiagnosticDataCell.swift
@@ -10,9 +10,9 @@ final class DiagnosticDataCell: UICollectionViewCell, ReusableView, NibLoadableV
     @IBOutlet weak var containerView: UIView!
     @IBOutlet weak var headerBackgroundView: UIView!
     @IBOutlet weak var iconImageView: UIImageView!
-
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var dataStackView: UIStackView!
+    @IBOutlet weak var cellWidthConstraint: NSLayoutConstraint!
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -31,6 +31,7 @@ final class DiagnosticDataCell: UICollectionViewCell, ReusableView, NibLoadableV
     }
 
     func setupStyle() {
+        contentView.translatesAutoresizingMaskIntoConstraints = false
         contentView.backgroundColor = Colors.transparent
         backgroundView?.backgroundColor = Colors.transparent
         containerView.backgroundColor = Colors.white
@@ -47,14 +48,13 @@ final class DiagnosticDataCell: UICollectionViewCell, ReusableView, NibLoadableV
 
     func update(with diagnostic: DiagnosticDataCell.ViewModel) {
         let fields: [String] = [
+            diagnostic.walletAddress,
+            diagnostic.walletCreation,
+            diagnostic.walletPassphrase,
             diagnostic.device,
             diagnostic.osVersion,
             diagnostic.appVersion,
-            diagnostic.locale,
-            diagnostic.batteryState,
-            diagnostic.walletAddress,
-            diagnostic.walletCreation,
-            diagnostic.walletPassphrase
+            diagnostic.batteryState
             ].compactMap { return $0 }
 
         let labelFont = UIFont.systemFont(ofSize: 14, weight: .light)
@@ -66,8 +66,20 @@ final class DiagnosticDataCell: UICollectionViewCell, ReusableView, NibLoadableV
             label.font = labelFont
             label.textColor = Colors.transactionCellDarkGray
             label.text = field
+            label.lineBreakMode = .byTruncatingMiddle
             dataStackView.addArrangedSubview(label)
         }
+    }
+
+    override func preferredLayoutAttributesFitting(
+        _ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
+        setNeedsLayout()
+        layoutIfNeeded()
+        let size = contentView.systemLayoutSizeFitting(layoutAttributes.size)
+        var frame = layoutAttributes.frame
+        frame.size.height = ceil(size.height)
+        layoutAttributes.frame = frame
+        return layoutAttributes
     }
 }
 

--- a/BlockEQ/Views/Cells/Diagnostics/DiagnosticDataCell.xib
+++ b/BlockEQ/Views/Cells/Diagnostics/DiagnosticDataCell.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -12,102 +12,108 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="RmB-Ww-QyO" userLabel="Content View" customClass="DiagnosticDataCell" customModule="BlockEQ" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="C56-wj-Eee" customClass="DiagnosticDataCell" customModule="BlockEQ" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="315" height="456"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Gi-Oc-BsE" userLabel="Container View">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                    <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E3I-h9-0Ai" userLabel="Header View">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="100"/>
-                            <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zrS-3z-2LD" userLabel="Header Circle">
-                                    <rect key="frame" x="157.5" y="25" width="60" height="60"/>
-                                    <subviews>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7Vh-lx-ouY">
-                                            <rect key="frame" x="10" y="10" width="40" height="40"/>
-                                        </imageView>
-                                    </subviews>
-                                    <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="7Vh-lx-ouY" secondAttribute="bottom" constant="10" id="1S7-3N-jWV"/>
-                                        <constraint firstAttribute="height" constant="60" id="5zd-ey-fU9"/>
-                                        <constraint firstAttribute="width" constant="60" id="F4d-Gh-Vec"/>
-                                        <constraint firstItem="7Vh-lx-ouY" firstAttribute="top" secondItem="zrS-3z-2LD" secondAttribute="top" constant="10" id="fy0-7k-8fu"/>
-                                        <constraint firstItem="7Vh-lx-ouY" firstAttribute="leading" secondItem="zrS-3z-2LD" secondAttribute="leading" constant="10" id="lIR-Wh-CKp"/>
-                                        <constraint firstAttribute="trailing" secondItem="7Vh-lx-ouY" secondAttribute="trailing" constant="10" id="pXU-fV-NZD"/>
-                                    </constraints>
-                                </view>
-                            </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstItem="zrS-3z-2LD" firstAttribute="top" secondItem="E3I-h9-0Ai" secondAttribute="top" constant="25" id="HRm-U6-fux"/>
-                                <constraint firstItem="zrS-3z-2LD" firstAttribute="centerX" secondItem="E3I-h9-0Ai" secondAttribute="centerX" id="M7c-N7-3sG"/>
-                                <constraint firstAttribute="bottom" secondItem="zrS-3z-2LD" secondAttribute="bottom" constant="15" id="tMt-Cl-GDB"/>
-                            </constraints>
-                        </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2a4-gJ-xLO" userLabel="Summary View">
-                            <rect key="frame" x="25" y="100" width="325" height="567"/>
-                            <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="749" text="Diagnostic Data" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7VB-d9-2yM" userLabel="Page Title Label">
-                                    <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" verticalCompressionResistancePriority="751" axis="vertical" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="nVY-he-sXv" userLabel="Data List">
-                                    <rect key="frame" x="0.0" y="30.5" width="325" height="20.5"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fe2-36-UKQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </stackView>
-                            </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstItem="nVY-he-sXv" firstAttribute="top" secondItem="7VB-d9-2yM" secondAttribute="bottom" constant="10" id="F46-GO-HMd"/>
-                                <constraint firstItem="nVY-he-sXv" firstAttribute="leading" secondItem="2a4-gJ-xLO" secondAttribute="leading" id="VEO-78-wQM"/>
-                                <constraint firstAttribute="trailing" secondItem="7VB-d9-2yM" secondAttribute="trailing" id="adH-vL-TPh"/>
-                                <constraint firstAttribute="trailing" secondItem="nVY-he-sXv" secondAttribute="trailing" id="cXT-QC-TvL"/>
-                                <constraint firstItem="7VB-d9-2yM" firstAttribute="top" secondItem="2a4-gJ-xLO" secondAttribute="top" id="gov-LS-gh3"/>
-                                <constraint firstItem="7VB-d9-2yM" firstAttribute="leading" secondItem="2a4-gJ-xLO" secondAttribute="leading" id="mAn-fn-u4n"/>
-                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="nVY-he-sXv" secondAttribute="bottom" constant="25" id="w61-9i-Vgq"/>
-                            </constraints>
-                        </view>
-                    </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstAttribute="bottom" secondItem="2a4-gJ-xLO" secondAttribute="bottom" id="4wr-Zr-GOc"/>
-                        <constraint firstItem="E3I-h9-0Ai" firstAttribute="leading" secondItem="7Gi-Oc-BsE" secondAttribute="leading" id="Ail-7E-BxF"/>
-                        <constraint firstAttribute="trailing" secondItem="2a4-gJ-xLO" secondAttribute="trailing" constant="25" id="NLp-ne-xqf"/>
-                        <constraint firstItem="E3I-h9-0Ai" firstAttribute="top" secondItem="7Gi-Oc-BsE" secondAttribute="top" id="Wwo-US-oZ2"/>
-                        <constraint firstItem="2a4-gJ-xLO" firstAttribute="leading" secondItem="7Gi-Oc-BsE" secondAttribute="leading" constant="25" id="ZUv-00-4hS"/>
-                        <constraint firstItem="2a4-gJ-xLO" firstAttribute="top" secondItem="E3I-h9-0Ai" secondAttribute="bottom" id="kif-tt-44B"/>
-                        <constraint firstAttribute="trailing" secondItem="E3I-h9-0Ai" secondAttribute="trailing" id="m0c-nz-7Uo"/>
-                    </constraints>
-                </view>
-            </subviews>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
+                <rect key="frame" x="0.0" y="0.0" width="315" height="456"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Gi-Oc-BsE" userLabel="Container View">
+                        <rect key="frame" x="0.0" y="0.0" width="315" height="456"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E3I-h9-0Ai" userLabel="Header View">
+                                <rect key="frame" x="0.0" y="0.0" width="315" height="100"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zrS-3z-2LD" userLabel="Header Circle">
+                                        <rect key="frame" x="127.5" y="25" width="60" height="60"/>
+                                        <subviews>
+                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7Vh-lx-ouY">
+                                                <rect key="frame" x="10" y="10" width="40" height="40"/>
+                                            </imageView>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="7Vh-lx-ouY" secondAttribute="bottom" constant="10" id="1S7-3N-jWV"/>
+                                            <constraint firstAttribute="height" constant="60" id="5zd-ey-fU9"/>
+                                            <constraint firstAttribute="width" constant="60" id="F4d-Gh-Vec"/>
+                                            <constraint firstItem="7Vh-lx-ouY" firstAttribute="top" secondItem="zrS-3z-2LD" secondAttribute="top" constant="10" id="fy0-7k-8fu"/>
+                                            <constraint firstItem="7Vh-lx-ouY" firstAttribute="leading" secondItem="zrS-3z-2LD" secondAttribute="leading" constant="10" id="lIR-Wh-CKp"/>
+                                            <constraint firstAttribute="trailing" secondItem="7Vh-lx-ouY" secondAttribute="trailing" constant="10" id="pXU-fV-NZD"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="zrS-3z-2LD" firstAttribute="top" secondItem="E3I-h9-0Ai" secondAttribute="top" constant="25" id="HRm-U6-fux"/>
+                                    <constraint firstItem="zrS-3z-2LD" firstAttribute="centerX" secondItem="E3I-h9-0Ai" secondAttribute="centerX" id="M7c-N7-3sG"/>
+                                    <constraint firstAttribute="bottom" secondItem="zrS-3z-2LD" secondAttribute="bottom" constant="15" id="tMt-Cl-GDB"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2a4-gJ-xLO" userLabel="Summary View">
+                                <rect key="frame" x="25" y="100" width="265" height="356"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Diagnostic Data" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7VB-d9-2yM" userLabel="Page Title Label">
+                                        <rect key="frame" x="0.0" y="0.0" width="265" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="nVY-he-sXv" userLabel="Data List">
+                                        <rect key="frame" x="0.0" y="35.5" width="265" height="305.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fe2-36-UKQ">
+                                                <rect key="frame" x="0.0" y="0.0" width="265" height="305.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="nVY-he-sXv" firstAttribute="top" secondItem="7VB-d9-2yM" secondAttribute="bottom" constant="15" id="F46-GO-HMd"/>
+                                    <constraint firstItem="nVY-he-sXv" firstAttribute="leading" secondItem="2a4-gJ-xLO" secondAttribute="leading" id="VEO-78-wQM"/>
+                                    <constraint firstAttribute="trailing" secondItem="7VB-d9-2yM" secondAttribute="trailing" id="adH-vL-TPh"/>
+                                    <constraint firstAttribute="trailing" secondItem="nVY-he-sXv" secondAttribute="trailing" id="cXT-QC-TvL"/>
+                                    <constraint firstItem="7VB-d9-2yM" firstAttribute="top" secondItem="2a4-gJ-xLO" secondAttribute="top" id="gov-LS-gh3"/>
+                                    <constraint firstItem="7VB-d9-2yM" firstAttribute="leading" secondItem="2a4-gJ-xLO" secondAttribute="leading" id="mAn-fn-u4n"/>
+                                    <constraint firstAttribute="bottom" secondItem="nVY-he-sXv" secondAttribute="bottom" constant="15" id="w61-9i-Vgq"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="2a4-gJ-xLO" secondAttribute="bottom" id="4wr-Zr-GOc"/>
+                            <constraint firstItem="E3I-h9-0Ai" firstAttribute="leading" secondItem="7Gi-Oc-BsE" secondAttribute="leading" id="Ail-7E-BxF"/>
+                            <constraint firstAttribute="trailing" secondItem="2a4-gJ-xLO" secondAttribute="trailing" constant="25" id="NLp-ne-xqf"/>
+                            <constraint firstAttribute="width" constant="315" id="UbB-gY-FeW"/>
+                            <constraint firstItem="E3I-h9-0Ai" firstAttribute="top" secondItem="7Gi-Oc-BsE" secondAttribute="top" id="Wwo-US-oZ2"/>
+                            <constraint firstItem="2a4-gJ-xLO" firstAttribute="leading" secondItem="7Gi-Oc-BsE" secondAttribute="leading" constant="25" id="ZUv-00-4hS"/>
+                            <constraint firstItem="2a4-gJ-xLO" firstAttribute="top" secondItem="E3I-h9-0Ai" secondAttribute="bottom" id="kif-tt-44B"/>
+                            <constraint firstAttribute="trailing" secondItem="E3I-h9-0Ai" secondAttribute="trailing" id="m0c-nz-7Uo"/>
+                        </constraints>
+                    </view>
+                </subviews>
+            </view>
             <constraints>
-                <constraint firstItem="7Gi-Oc-BsE" firstAttribute="leading" secondItem="RmB-Ww-QyO" secondAttribute="leading" id="WHF-a0-LFU"/>
-                <constraint firstItem="7Gi-Oc-BsE" firstAttribute="top" secondItem="RmB-Ww-QyO" secondAttribute="top" id="WjZ-qR-F4s"/>
-                <constraint firstItem="bx1-gm-epI" firstAttribute="bottom" secondItem="7Gi-Oc-BsE" secondAttribute="bottom" id="drI-aS-HnR"/>
-                <constraint firstAttribute="trailing" secondItem="7Gi-Oc-BsE" secondAttribute="trailing" id="qll-1M-bBj"/>
+                <constraint firstAttribute="trailing" secondItem="7Gi-Oc-BsE" secondAttribute="trailing" id="3jN-tE-MeW"/>
+                <constraint firstAttribute="bottom" secondItem="7Gi-Oc-BsE" secondAttribute="bottom" id="Ggu-S9-0Mf"/>
+                <constraint firstItem="7Gi-Oc-BsE" firstAttribute="leading" secondItem="C56-wj-Eee" secondAttribute="leading" id="hTb-21-waC"/>
+                <constraint firstItem="7Gi-Oc-BsE" firstAttribute="top" secondItem="C56-wj-Eee" secondAttribute="top" id="k93-Ov-mui"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="bx1-gm-epI"/>
+            <viewLayoutGuide key="safeArea" id="X46-si-jFf"/>
+            <size key="customSize" width="315" height="456"/>
             <connections>
-                <outlet property="containerView" destination="7Gi-Oc-BsE" id="uw4-Q3-AsW"/>
-                <outlet property="dataStackView" destination="nVY-he-sXv" id="8gn-Ob-5Bo"/>
-                <outlet property="headerBackgroundView" destination="zrS-3z-2LD" id="UTN-mL-max"/>
-                <outlet property="iconImageView" destination="7Vh-lx-ouY" id="6TT-J0-qNA"/>
-                <outlet property="titleLabel" destination="7VB-d9-2yM" id="QPJ-eF-iFv"/>
+                <outlet property="cellWidthConstraint" destination="UbB-gY-FeW" id="fqR-WK-95I"/>
+                <outlet property="containerView" destination="7Gi-Oc-BsE" id="4qc-3u-hiC"/>
+                <outlet property="dataStackView" destination="nVY-he-sXv" id="e8i-0g-sic"/>
+                <outlet property="headerBackgroundView" destination="zrS-3z-2LD" id="obM-bg-4jH"/>
+                <outlet property="iconImageView" destination="7Vh-lx-ouY" id="RZY-3A-XXi"/>
+                <outlet property="titleLabel" destination="7VB-d9-2yM" id="T5S-EC-8tO"/>
             </connections>
-            <point key="canvasLocation" x="-642.39999999999998" y="711.99400299850083"/>
-        </view>
+            <point key="canvasLocation" x="-394.6875" y="1391.1971830985915"/>
+        </collectionViewCell>
     </objects>
 </document>

--- a/BlockEQ/Views/Cells/Diagnostics/DiagnosticInputCell.swift
+++ b/BlockEQ/Views/Cells/Diagnostics/DiagnosticInputCell.swift
@@ -1,5 +1,5 @@
 //
-//  DiagnosticCardCell.swift
+//  DiagnosticInputCell.swift
 //  BlockEQ
 //
 //  Created by Nick DiZazzo on 2018-11-12.
@@ -12,8 +12,11 @@ final class DiagnosticInputCell: UICollectionViewCell, ReusableView, NibLoadable
     @IBOutlet weak var containerView: UIView!
     @IBOutlet weak var headerBackgroundView: UIView!
     @IBOutlet weak var iconImageView: UIImageView!
-    @IBOutlet weak var issueSummaryLabel: UILabel!
-    @IBOutlet weak var emailLabel: UILabel!
+    @IBOutlet weak var summaryTitleLabel: UILabel!
+    @IBOutlet weak var emailTitleLabel: UILabel!
+    @IBOutlet weak var summaryTextField: UITextField!
+    @IBOutlet weak var emailTextField: UITextField!
+    @IBOutlet weak var cellWidthConstraint: NSLayoutConstraint!
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -32,6 +35,8 @@ final class DiagnosticInputCell: UICollectionViewCell, ReusableView, NibLoadable
     }
 
     func setupStyle() {
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        
         contentView.backgroundColor = Colors.transparent
         backgroundView?.backgroundColor = Colors.transparent
         containerView.backgroundColor = Colors.white
@@ -41,12 +46,12 @@ final class DiagnosticInputCell: UICollectionViewCell, ReusableView, NibLoadable
         iconImageView.tintColor = Colors.white
         iconImageView.contentMode = .scaleAspectFit
 
-        issueSummaryLabel.font = UIFont.systemFont(ofSize: 18, weight: .heavy)
-        issueSummaryLabel.text = "ISSUE_SUMMARY".localized()
-        issueSummaryLabel.textColor = Colors.transactionCellDarkGray
+        summaryTitleLabel.font = UIFont.systemFont(ofSize: 18, weight: .heavy)
+        summaryTitleLabel.text = "ISSUE_SUMMARY".localized()
+        summaryTitleLabel.textColor = Colors.transactionCellDarkGray
 
-        emailLabel.font = UIFont.systemFont(ofSize: 18, weight: .heavy)
-        emailLabel.text = "EMAIL_ADDRESS".localized()
-        emailLabel.textColor = Colors.transactionCellDarkGray
+        emailTitleLabel.font = UIFont.systemFont(ofSize: 18, weight: .heavy)
+        emailTitleLabel.text = "EMAIL_ADDRESS".localized()
+        emailTitleLabel.textColor = Colors.transactionCellDarkGray
     }
 }

--- a/BlockEQ/Views/Cells/Diagnostics/DiagnosticInputCell.xib
+++ b/BlockEQ/Views/Cells/Diagnostics/DiagnosticInputCell.xib
@@ -12,151 +12,159 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="DiagnosticInputCell" customModule="BlockEQ" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ePa-Y7-Dt5" userLabel="Container View">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                    <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RG0-1S-ZSw" userLabel="Header View">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="100"/>
-                            <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p9J-1c-WGj" userLabel="Header Circle">
-                                    <rect key="frame" x="157.5" y="25" width="60" height="60"/>
-                                    <subviews>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="4Ag-Vr-p22">
-                                            <rect key="frame" x="10" y="10" width="40" height="40"/>
-                                        </imageView>
-                                    </subviews>
-                                    <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstItem="4Ag-Vr-p22" firstAttribute="leading" secondItem="p9J-1c-WGj" secondAttribute="leading" constant="10" id="8q5-gk-zvk"/>
-                                        <constraint firstAttribute="bottom" secondItem="4Ag-Vr-p22" secondAttribute="bottom" constant="10" id="B47-hU-n3Q"/>
-                                        <constraint firstAttribute="height" constant="60" id="NGZ-oO-x4a"/>
-                                        <constraint firstItem="4Ag-Vr-p22" firstAttribute="top" secondItem="p9J-1c-WGj" secondAttribute="top" constant="10" id="Qfm-Dt-nOq"/>
-                                        <constraint firstAttribute="width" constant="60" id="a3d-a3-yTO"/>
-                                        <constraint firstAttribute="trailing" secondItem="4Ag-Vr-p22" secondAttribute="trailing" constant="10" id="x28-pB-vzW"/>
-                                    </constraints>
-                                </view>
-                            </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstAttribute="bottom" secondItem="p9J-1c-WGj" secondAttribute="bottom" constant="15" id="9pS-pT-Jfy"/>
-                                <constraint firstItem="p9J-1c-WGj" firstAttribute="top" secondItem="RG0-1S-ZSw" secondAttribute="top" constant="25" id="ECJ-hR-Aqv"/>
-                                <constraint firstItem="p9J-1c-WGj" firstAttribute="centerX" secondItem="RG0-1S-ZSw" secondAttribute="centerX" id="NjP-U3-179"/>
-                            </constraints>
-                        </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NK1-ee-EPe" userLabel="Summary View">
-                            <rect key="frame" x="25" y="100" width="325" height="567"/>
-                            <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tWF-Rs-dVH">
-                                    <rect key="frame" x="0.0" y="188" width="325" height="141"/>
-                                    <subviews>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fo5-zN-rXc" userLabel="Summary Container">
-                                            <rect key="frame" x="0.0" y="0.0" width="325" height="80.5"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="749" text="Issue Summary" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VrI-tp-O0D" userLabel="Issue Summary Title">
-                                                    <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="R9V-qi-0LX" userLabel="Summary Text">
-                                                    <rect key="frame" x="0.0" y="30.5" width="325" height="30"/>
-                                                    <nil key="textColor"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                            </subviews>
-                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="VrI-tp-O0D" secondAttribute="trailing" id="523-Gv-K0l"/>
-                                                <constraint firstAttribute="bottom" secondItem="R9V-qi-0LX" secondAttribute="bottom" constant="20" id="6Wm-Ru-vBI"/>
-                                                <constraint firstItem="R9V-qi-0LX" firstAttribute="leading" secondItem="Fo5-zN-rXc" secondAttribute="leading" id="8zb-02-TIF"/>
-                                                <constraint firstItem="VrI-tp-O0D" firstAttribute="top" secondItem="Fo5-zN-rXc" secondAttribute="top" id="JdK-j8-3Bi"/>
-                                                <constraint firstAttribute="trailing" secondItem="R9V-qi-0LX" secondAttribute="trailing" id="LN3-r4-www"/>
-                                                <constraint firstItem="R9V-qi-0LX" firstAttribute="top" secondItem="VrI-tp-O0D" secondAttribute="bottom" constant="10" id="aQt-O8-v2y"/>
-                                                <constraint firstItem="VrI-tp-O0D" firstAttribute="leading" secondItem="Fo5-zN-rXc" secondAttribute="leading" id="d9j-hY-CgV"/>
-                                            </constraints>
-                                        </view>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dVv-pz-DiX" userLabel="Email Container">
-                                            <rect key="frame" x="0.0" y="80.5" width="325" height="60.5"/>
-                                            <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="b3W-1Z-Mql" userLabel="Email Text">
-                                                    <rect key="frame" x="0.0" y="30.5" width="325" height="30"/>
-                                                    <nil key="textColor"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="749" text="Email Address" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MMY-me-i07" userLabel="Email Title">
-                                                    <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            <constraints>
-                                                <constraint firstItem="MMY-me-i07" firstAttribute="leading" secondItem="dVv-pz-DiX" secondAttribute="leading" id="0Mz-9o-nFI"/>
-                                                <constraint firstItem="b3W-1Z-Mql" firstAttribute="leading" secondItem="dVv-pz-DiX" secondAttribute="leading" id="3sG-4h-NCH"/>
-                                                <constraint firstAttribute="trailing" secondItem="b3W-1Z-Mql" secondAttribute="trailing" id="FnN-FX-c38"/>
-                                                <constraint firstItem="MMY-me-i07" firstAttribute="top" secondItem="dVv-pz-DiX" secondAttribute="top" id="MG5-ak-7Pf"/>
-                                                <constraint firstAttribute="bottom" secondItem="b3W-1Z-Mql" secondAttribute="bottom" id="Ogy-MX-gtm"/>
-                                                <constraint firstItem="b3W-1Z-Mql" firstAttribute="top" secondItem="MMY-me-i07" secondAttribute="bottom" constant="10" id="UBX-Hi-ywV"/>
-                                                <constraint firstAttribute="trailing" secondItem="MMY-me-i07" secondAttribute="trailing" id="gHX-XH-i8u"/>
-                                            </constraints>
-                                        </view>
-                                    </subviews>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="trailing" secondItem="Fo5-zN-rXc" secondAttribute="trailing" id="2vu-8E-cdR"/>
-                                        <constraint firstItem="dVv-pz-DiX" firstAttribute="leading" secondItem="tWF-Rs-dVH" secondAttribute="leading" id="DUK-qX-ItV"/>
-                                        <constraint firstItem="Fo5-zN-rXc" firstAttribute="leading" secondItem="tWF-Rs-dVH" secondAttribute="leading" id="QY1-jV-cMu"/>
-                                        <constraint firstItem="Fo5-zN-rXc" firstAttribute="top" secondItem="tWF-Rs-dVH" secondAttribute="top" id="Sya-oh-M0l"/>
-                                        <constraint firstAttribute="trailing" secondItem="dVv-pz-DiX" secondAttribute="trailing" id="W32-lk-8Dq"/>
-                                        <constraint firstAttribute="bottom" secondItem="dVv-pz-DiX" secondAttribute="bottom" id="YhK-QT-3Ow"/>
-                                        <constraint firstItem="dVv-pz-DiX" firstAttribute="top" secondItem="Fo5-zN-rXc" secondAttribute="bottom" id="hqF-An-Blx"/>
-                                    </constraints>
-                                </view>
-                            </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstItem="tWF-Rs-dVH" firstAttribute="centerY" secondItem="NK1-ee-EPe" secondAttribute="centerY" constant="-25" id="41c-J0-ftC"/>
-                                <constraint firstAttribute="trailing" secondItem="tWF-Rs-dVH" secondAttribute="trailing" id="8zJ-uC-UoP"/>
-                                <constraint firstItem="tWF-Rs-dVH" firstAttribute="leading" secondItem="NK1-ee-EPe" secondAttribute="leading" id="Xhq-o4-26Y"/>
-                            </constraints>
-                        </view>
-                    </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstItem="NK1-ee-EPe" firstAttribute="top" secondItem="RG0-1S-ZSw" secondAttribute="bottom" id="dKr-xQ-GWa"/>
-                        <constraint firstItem="RG0-1S-ZSw" firstAttribute="top" secondItem="ePa-Y7-Dt5" secondAttribute="top" id="i48-z7-v0j"/>
-                        <constraint firstAttribute="trailing" secondItem="NK1-ee-EPe" secondAttribute="trailing" constant="25" id="nLz-Yt-5DN"/>
-                        <constraint firstItem="RG0-1S-ZSw" firstAttribute="leading" secondItem="ePa-Y7-Dt5" secondAttribute="leading" id="pbf-89-Xv9"/>
-                        <constraint firstItem="NK1-ee-EPe" firstAttribute="leading" secondItem="ePa-Y7-Dt5" secondAttribute="leading" constant="25" id="rXw-Bn-RHf"/>
-                        <constraint firstAttribute="bottom" secondItem="NK1-ee-EPe" secondAttribute="bottom" id="tWY-2X-si9"/>
-                        <constraint firstAttribute="trailing" secondItem="RG0-1S-ZSw" secondAttribute="trailing" id="vTf-2c-DlU"/>
-                    </constraints>
-                    <viewLayoutGuide key="safeArea" id="06k-iW-IC1"/>
-                </view>
-            </subviews>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="ivk-VH-aro" customClass="DiagnosticInputCell" customModule="BlockEQ" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="315" height="283"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
+                <rect key="frame" x="0.0" y="0.0" width="315" height="283"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ePa-Y7-Dt5" userLabel="Container View">
+                        <rect key="frame" x="0.0" y="0.0" width="315" height="283"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RG0-1S-ZSw" userLabel="Header View">
+                                <rect key="frame" x="0.0" y="0.0" width="315" height="100"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p9J-1c-WGj" userLabel="Header Circle">
+                                        <rect key="frame" x="127.5" y="25" width="60" height="60"/>
+                                        <subviews>
+                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="4Ag-Vr-p22">
+                                                <rect key="frame" x="10" y="10" width="40" height="40"/>
+                                            </imageView>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="4Ag-Vr-p22" firstAttribute="leading" secondItem="p9J-1c-WGj" secondAttribute="leading" constant="10" id="8q5-gk-zvk"/>
+                                            <constraint firstAttribute="bottom" secondItem="4Ag-Vr-p22" secondAttribute="bottom" constant="10" id="B47-hU-n3Q"/>
+                                            <constraint firstAttribute="height" constant="60" id="NGZ-oO-x4a"/>
+                                            <constraint firstItem="4Ag-Vr-p22" firstAttribute="top" secondItem="p9J-1c-WGj" secondAttribute="top" constant="10" id="Qfm-Dt-nOq"/>
+                                            <constraint firstAttribute="width" constant="60" id="a3d-a3-yTO"/>
+                                            <constraint firstAttribute="trailing" secondItem="4Ag-Vr-p22" secondAttribute="trailing" constant="10" id="x28-pB-vzW"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="p9J-1c-WGj" secondAttribute="bottom" constant="15" id="9pS-pT-Jfy"/>
+                                    <constraint firstItem="p9J-1c-WGj" firstAttribute="top" secondItem="RG0-1S-ZSw" secondAttribute="top" constant="25" id="ECJ-hR-Aqv"/>
+                                    <constraint firstItem="p9J-1c-WGj" firstAttribute="centerX" secondItem="RG0-1S-ZSw" secondAttribute="centerX" id="NjP-U3-179"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NK1-ee-EPe" userLabel="Summary View">
+                                <rect key="frame" x="25" y="100" width="265" height="183"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tWF-Rs-dVH">
+                                        <rect key="frame" x="0.0" y="-4" width="265" height="141"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fo5-zN-rXc" userLabel="Summary Container">
+                                                <rect key="frame" x="0.0" y="0.0" width="265" height="80.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="749" text="Issue Summary" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VrI-tp-O0D" userLabel="Issue Summary Title">
+                                                        <rect key="frame" x="0.0" y="0.0" width="265" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="R9V-qi-0LX" userLabel="Summary Text">
+                                                        <rect key="frame" x="0.0" y="30.5" width="265" height="30"/>
+                                                        <nil key="textColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="trailing" secondItem="VrI-tp-O0D" secondAttribute="trailing" id="523-Gv-K0l"/>
+                                                    <constraint firstAttribute="bottom" secondItem="R9V-qi-0LX" secondAttribute="bottom" constant="20" id="6Wm-Ru-vBI"/>
+                                                    <constraint firstItem="R9V-qi-0LX" firstAttribute="leading" secondItem="Fo5-zN-rXc" secondAttribute="leading" id="8zb-02-TIF"/>
+                                                    <constraint firstItem="VrI-tp-O0D" firstAttribute="top" secondItem="Fo5-zN-rXc" secondAttribute="top" id="JdK-j8-3Bi"/>
+                                                    <constraint firstAttribute="trailing" secondItem="R9V-qi-0LX" secondAttribute="trailing" id="LN3-r4-www"/>
+                                                    <constraint firstItem="R9V-qi-0LX" firstAttribute="top" secondItem="VrI-tp-O0D" secondAttribute="bottom" constant="10" id="aQt-O8-v2y"/>
+                                                    <constraint firstItem="VrI-tp-O0D" firstAttribute="leading" secondItem="Fo5-zN-rXc" secondAttribute="leading" id="d9j-hY-CgV"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dVv-pz-DiX" userLabel="Email Container">
+                                                <rect key="frame" x="0.0" y="80.5" width="265" height="60.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="749" text="Email Address" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MMY-me-i07" userLabel="Email Title">
+                                                        <rect key="frame" x="0.0" y="0.0" width="265" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="b3W-1Z-Mql" userLabel="Email Text">
+                                                        <rect key="frame" x="0.0" y="30.5" width="265" height="30"/>
+                                                        <nil key="textColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstItem="MMY-me-i07" firstAttribute="leading" secondItem="dVv-pz-DiX" secondAttribute="leading" id="0Mz-9o-nFI"/>
+                                                    <constraint firstItem="b3W-1Z-Mql" firstAttribute="leading" secondItem="dVv-pz-DiX" secondAttribute="leading" id="3sG-4h-NCH"/>
+                                                    <constraint firstAttribute="trailing" secondItem="b3W-1Z-Mql" secondAttribute="trailing" id="FnN-FX-c38"/>
+                                                    <constraint firstItem="MMY-me-i07" firstAttribute="top" secondItem="dVv-pz-DiX" secondAttribute="top" id="MG5-ak-7Pf"/>
+                                                    <constraint firstAttribute="bottom" secondItem="b3W-1Z-Mql" secondAttribute="bottom" id="Ogy-MX-gtm"/>
+                                                    <constraint firstItem="b3W-1Z-Mql" firstAttribute="top" secondItem="MMY-me-i07" secondAttribute="bottom" constant="10" id="UBX-Hi-ywV"/>
+                                                    <constraint firstAttribute="trailing" secondItem="MMY-me-i07" secondAttribute="trailing" id="gHX-XH-i8u"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="Fo5-zN-rXc" secondAttribute="trailing" id="2vu-8E-cdR"/>
+                                            <constraint firstItem="dVv-pz-DiX" firstAttribute="leading" secondItem="tWF-Rs-dVH" secondAttribute="leading" id="DUK-qX-ItV"/>
+                                            <constraint firstItem="Fo5-zN-rXc" firstAttribute="leading" secondItem="tWF-Rs-dVH" secondAttribute="leading" id="QY1-jV-cMu"/>
+                                            <constraint firstItem="Fo5-zN-rXc" firstAttribute="top" secondItem="tWF-Rs-dVH" secondAttribute="top" id="Sya-oh-M0l"/>
+                                            <constraint firstAttribute="trailing" secondItem="dVv-pz-DiX" secondAttribute="trailing" id="W32-lk-8Dq"/>
+                                            <constraint firstAttribute="bottom" secondItem="dVv-pz-DiX" secondAttribute="bottom" id="YhK-QT-3Ow"/>
+                                            <constraint firstItem="dVv-pz-DiX" firstAttribute="top" secondItem="Fo5-zN-rXc" secondAttribute="bottom" id="hqF-An-Blx"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="tWF-Rs-dVH" firstAttribute="centerY" secondItem="NK1-ee-EPe" secondAttribute="centerY" constant="-25" id="41c-J0-ftC"/>
+                                    <constraint firstAttribute="trailing" secondItem="tWF-Rs-dVH" secondAttribute="trailing" id="8zJ-uC-UoP"/>
+                                    <constraint firstItem="tWF-Rs-dVH" firstAttribute="leading" secondItem="NK1-ee-EPe" secondAttribute="leading" id="Xhq-o4-26Y"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="315" id="Lxh-8l-zYy"/>
+                            <constraint firstItem="NK1-ee-EPe" firstAttribute="top" secondItem="RG0-1S-ZSw" secondAttribute="bottom" id="dKr-xQ-GWa"/>
+                            <constraint firstItem="RG0-1S-ZSw" firstAttribute="top" secondItem="ePa-Y7-Dt5" secondAttribute="top" id="i48-z7-v0j"/>
+                            <constraint firstAttribute="trailing" secondItem="NK1-ee-EPe" secondAttribute="trailing" constant="25" id="nLz-Yt-5DN"/>
+                            <constraint firstItem="RG0-1S-ZSw" firstAttribute="leading" secondItem="ePa-Y7-Dt5" secondAttribute="leading" id="pbf-89-Xv9"/>
+                            <constraint firstItem="NK1-ee-EPe" firstAttribute="leading" secondItem="ePa-Y7-Dt5" secondAttribute="leading" constant="25" id="rXw-Bn-RHf"/>
+                            <constraint firstAttribute="bottom" secondItem="NK1-ee-EPe" secondAttribute="bottom" id="tWY-2X-si9"/>
+                            <constraint firstAttribute="trailing" secondItem="RG0-1S-ZSw" secondAttribute="trailing" id="vTf-2c-DlU"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="06k-iW-IC1"/>
+                    </view>
+                </subviews>
+            </view>
             <constraints>
-                <constraint firstItem="ePa-Y7-Dt5" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="0LB-Qh-Fwe"/>
-                <constraint firstItem="ePa-Y7-Dt5" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="BPt-fU-sJ8"/>
-                <constraint firstItem="ePa-Y7-Dt5" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="afd-IQ-q04"/>
-                <constraint firstItem="ePa-Y7-Dt5" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="dkM-oH-oUy"/>
+                <constraint firstAttribute="bottom" secondItem="ePa-Y7-Dt5" secondAttribute="bottom" id="CqA-Tf-vJr"/>
+                <constraint firstItem="ePa-Y7-Dt5" firstAttribute="top" secondItem="ivk-VH-aro" secondAttribute="top" id="iHa-61-z2H"/>
+                <constraint firstAttribute="trailing" secondItem="ePa-Y7-Dt5" secondAttribute="trailing" id="iNc-pV-caa"/>
+                <constraint firstItem="ePa-Y7-Dt5" firstAttribute="leading" secondItem="ivk-VH-aro" secondAttribute="leading" id="q0n-RA-nfi"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <viewLayoutGuide key="safeArea" id="Mx1-IS-bix"/>
+            <size key="customSize" width="315" height="283"/>
             <connections>
-                <outlet property="containerView" destination="ePa-Y7-Dt5" id="OvA-gj-hJ3"/>
-                <outlet property="emailLabel" destination="MMY-me-i07" id="JXc-Oi-cig"/>
-                <outlet property="headerBackgroundView" destination="p9J-1c-WGj" id="tbc-Tn-St6"/>
-                <outlet property="iconImageView" destination="4Ag-Vr-p22" id="M4x-h9-tvC"/>
-                <outlet property="issueSummaryLabel" destination="VrI-tp-O0D" id="N0S-5r-xs1"/>
+                <outlet property="cellWidthConstraint" destination="Lxh-8l-zYy" id="6zc-6l-RFg"/>
+                <outlet property="containerView" destination="ePa-Y7-Dt5" id="UVV-xi-2LU"/>
+                <outlet property="emailTextField" destination="b3W-1Z-Mql" id="uXs-oZ-i7a"/>
+                <outlet property="emailTitleLabel" destination="MMY-me-i07" id="2Ys-rb-Fkj"/>
+                <outlet property="headerBackgroundView" destination="p9J-1c-WGj" id="MED-1b-dJ3"/>
+                <outlet property="iconImageView" destination="4Ag-Vr-p22" id="x85-jz-iNR"/>
+                <outlet property="summaryTextField" destination="R9V-qi-0LX" id="KN0-BO-6ls"/>
+                <outlet property="summaryTitleLabel" destination="VrI-tp-O0D" id="eUu-OS-daZ"/>
             </connections>
-            <point key="canvasLocation" x="38" y="47"/>
-        </view>
+            <point key="canvasLocation" x="349.60000000000002" y="570.76461769115451"/>
+        </collectionViewCell>
     </objects>
 </document>


### PR DESCRIPTION
## Priority
Normal

## Description
This PR automatically initializes `AppDiagnostic` when creating a `Diagnostic` object. This allows the app diagnostic screen to have hardware info / os version / app info, etc.

It also converts the `UICollectionViewCell`s for diagnostics into self-sizing cells so that they expand to the height they need to look better on tall devices, and still work on the iPhone 5S / SE. 
## Screenshot
<img width="504" alt="screen shot 2018-11-15 at 10 08 24 pm" src="https://user-images.githubusercontent.com/728690/48630936-6f30df80-e98b-11e8-89d1-61ab64bfc9fe.png">
