### PR TITLE
[FIX] Crash when indexing when running on a hardware device

### DIFF
--- a/BlockEQ/Resources/Info.plist
+++ b/BlockEQ/Resources/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>18</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/StellarAccountService/Services/StellarIndexingService.swift
+++ b/StellarAccountService/Services/StellarIndexingService.swift
@@ -72,9 +72,9 @@ public final class StellarIndexingService: StellarIndexingServiceProtocol {
         indexOperation.delegate = self
 
         indexOperation.completionBlock = { [unowned self] in
-            self.graph.edges.formUnion(indexOperation.edges)
-
             DispatchQueue.main.async {
+                self.graph.edges.formUnion(indexOperation.edges)
+
                 if indexOperation.result.isSuccess {
                     self.delegate?.finishedIndexing(self)
                 } else {


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects a crash when progressively updating the index due to not dispatching the update on the main thread and then trying to access the resultant objects.

## Screenshot
N/A
