### PR TITLE
[FEATURE] Added ability to store specific operation data in a StellarOperation

### DIFF
--- a/BlockEQ/Objects/StellarOperation+Extensions.swift
+++ b/BlockEQ/Objects/StellarOperation+Extensions.swift
@@ -28,24 +28,58 @@ extension StellarOperation {
 
     var descriptionString: String {
         switch operationType {
-        case .accountCreated: return "OPERATION_CREATED_DESCRIPTION".localized()
-        case .accountMerge: return "OPERATION_MERGED_DESCRIPTION".localized()
-        case .allowTrust: return "OPERATION_ATRUST_DESCRIPTION".localized()
-        case .bumpSequence: return "OPERATION_BUMP_DESCRIPTION".localized()
-        case .changeTrust: return "OPERATION_CTRUST_DESCRIPTION".localized()
-        case .createPassiveOffer: return "OPERATION_POFFER_DESCRIPTION".localized()
-        case .inflation: return"OPERATION_INFLATION_DESCRIPTION".localized()
-        case .manageData: return "OPERATION_MANAGEDATA_DESCRIPTION".localized()
-        case .manageOffer: return "OPERATION_MOFFER_DESCRIPTION".localized()
-        case .pathPayment: return "OPERATION_PATHPAYMENT_DESCRIPTION".localized()
-        case .payment: return"OPERATION_PAYMENT_DESCRIPTION".localized()
+        case .accountCreated:
+            guard let createData = self.createData else { return "" }
+            return String(format: "OPERATION_CREATED_DESCRIPTION".localized(),
+                          createData.account, createData.balance.displayFormattedString)
+        case .accountMerge:
+            guard let mergeData = self.mergeData else { return "" }
+            return String(format: "OPERATION_MERGED_DESCRIPTION".localized(), mergeData.from, mergeData.into)
+        case .allowTrust:
+            guard let trustData = self.allowTrustData else { return "" }
+            let allowDeny = trustData.allow ? "OPERATION_ALLOWTRUST".localized() : "OPERATION_DENYTRUST".localized()
+            return String(format: "OPERATION_ATRUST_DESCRIPTION".localized(),
+                          allowDeny,
+                          trustData.trustor,
+                          trustData.asset.shortCode,
+                          trustData.trustee)
+        case .changeTrust:
+            guard let trustData = self.changeTrustData else { return "" }
+            return String(format: "OPERATION_CTRUST_DESCRIPTION".localized(),
+                          trustData.asset.shortCode,
+                          trustData.trustee)
+        case .manageOffer:
+            guard let manageData = self.manageData else { return "" }
+            return String(format: "OPERATION_MOFFER_DESCRIPTION".localized(),
+                          manageData.pair.selling.shortCode,
+                          manageData.pair.buying.shortCode,
+                          manageData.price.displayFormatted,
+                          "\(manageData.pair.buying.shortCode)/\(manageData.pair.selling.shortCode)")
+        case .payment:
+            guard let paymentData = self.paymentData else { return "" }
+            return String(format: "OPERATION_PAYMENT_DESCRIPTION".localized(),
+                          paymentData.asset.shortCode,
+                          paymentData.destination)
         case .setOptions:
-            switch "0" { // fix when support for different operation types are available
-            case "0": return "OPERATION_OPTIONS_SET_INFLATION_DESCRIPTION".localized()
-            case "1": return "OPERATION_OPTIONS_SET_HOMEDOMAIN_DESCRIPTION".localized()
-            case "2": return "OPERATION_OPTIONS_SET_SIGNER_DESCRIPTION".localized()
-            default: return "OPERATION_OPTIONS_DESCRIPTION".localized()
+            if let inflationDest = self.optionsData?.inflationDest {
+                return String(format: "OPERATION_OPTIONS_SET_INFLATION_DESCRIPTION".localized(), inflationDest)
+            } else if let domain = self.optionsData?.homeDomain {
+                return String(format: "OPERATION_OPTIONS_SET_HOMEDOMAIN_DESCRIPTION".localized(), domain)
+            } else if let signer = self.optionsData?.signerKey, let weight = self.optionsData?.signerWeight {
+                return String(format: "OPERATION_OPTIONS_SET_SIGNER_DESCRIPTION".localized(), signer, weight)
+            } else {
+                return "OPERATION_OPTIONS_DESCRIPTION".localized()
             }
+        case .pathPayment:
+            return "OPERATION_PATHPAYMENT_DESCRIPTION".localized()
+        case .bumpSequence:
+            return "OPERATION_BUMP_DESCRIPTION".localized()
+        case .createPassiveOffer:
+            return "OPERATION_POFFER_DESCRIPTION".localized()
+        case .inflation:
+            return "OPERATION_INFLATION_DESCRIPTION".localized()
+        case .manageData:
+            return "OPERATION_MANAGEDATA_DESCRIPTION".localized()
         }
     }
 }

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -205,16 +205,18 @@
 "OPERATION_OPTIONS_TITLE" = "Set Options";
 
 "OPERATION_CREATED_DESCRIPTION" = "Account %@ created with starting balance %@ XLM ";
-"OPERATION_MERGED_DESCRIPTION" = "Account %@ merged with %@ ";
-"OPERATION_ATRUST_DESCRIPTION" = "Allow %@ to Trust %@ from %@ ";
+"OPERATION_MERGED_DESCRIPTION" = "Account %@ merged with %@";
+"OPERATION_ATRUST_DESCRIPTION" = "%@ %@ to trust %@ from %@";
+"OPERATION_ALLOWTRUST" = "Allow";
+"OPERATION_DENYTRUST" = "Disallow";
+"OPERATION_CTRUST_DESCRIPTION" = "Changed trustline to %@ from %@";
+"OPERATION_MOFFER_DESCRIPTION" = "Created offer selling %@ for %@ at %@ %@";
+"OPERATION_PAYMENT_DESCRIPTION" = "Sent %@ to %@";
 "OPERATION_BUMP_DESCRIPTION" = "Unsupported";
-"OPERATION_CTRUST_DESCRIPTION" = "Trustline %@ to %@ from %@";
 "OPERATION_POFFER_DESCRIPTION" = "Unsupported";
 "OPERATION_INFLATION_DESCRIPTION" = "Unsupported";
 "OPERATION_MANAGEDATA_DESCRIPTION" = "Unsupported";
-"OPERATION_MOFFER_DESCRIPTION" = "Created offer selling %@ %@ for %@ %@ at %@ %@";
-"OPERATION_PATHPAYMENT_DESCRIPTION" = "Unsupported ";
-"OPERATION_PAYMENT_DESCRIPTION" = "Sent %@ %@ to %@";
+"OPERATION_PATHPAYMENT_DESCRIPTION" = "Unsupported";
 
 "OPERATION_OPTIONS_SET_INFLATION_DESCRIPTION" = "Inflation destination set to %@";
 "OPERATION_OPTIONS_SET_HOMEDOMAIN_DESCRIPTION" = "Home domain set to %@";

--- a/StellarAccountService/Operations/Account/FetchOperationsOperation.swift
+++ b/StellarAccountService/Operations/Account/FetchOperationsOperation.swift
@@ -41,6 +41,13 @@ final class FetchAccountOperationsOperation: AsyncOperation {
                                          limit: recordCount) { operationResponse in
             switch operationResponse {
             case .success(let operationResponse):
+                /*
+                 ManageOfferOperationResponse
+                 PaymentOperationResponse
+                 ChangeTrustOperationResponse
+                 SetOptionsOperationResponse
+                 AccountCreatedOperationResponse
+                 */
                 let operations = operationResponse.records.map { StellarOperation($0) }
                 self.result = Result.success(operations)
             case .failure(let error):


### PR DESCRIPTION
## Priority
High

## Description
This PR adds more details into the `StellarOperation` struct so that it can be displayed in the `TransactionDetailsViewController`

## Screenshot
<img width="545" alt="screen shot 2018-11-18 at 5 15 31 pm" src="https://user-images.githubusercontent.com/728690/48678815-33964100-eb56-11e8-85d6-d72da27cadd4.png">
<img width="545" alt="screen shot 2018-11-18 at 5 16 16 pm" src="https://user-images.githubusercontent.com/728690/48678816-33964100-eb56-11e8-9b84-d566171922d4.png">

## Notes
Ideally, we would write wrapping subclassed types for `OperationResponse`, but I want to keep `StellarOperation` as a value type. This obviously has some implications since we have to check the type of operation at runtime instead of compile time, but it's useful to allow these objects to be passed across threads by value.