### PR TITLE
[FIX] Corrects behaviour with selecting assets in the trade view

### DIFF
--- a/BlockEQ/View Controllers/Trade/TradeViewController.swift
+++ b/BlockEQ/View Controllers/Trade/TradeViewController.swift
@@ -233,13 +233,13 @@ class TradeViewController: UIViewController {
         tradeToTextField.text = toValue.displayFormattedString
     }
 
-    func buildFromDataSource(with selectedAsset: StellarAsset?) {
+    func buildFromDataSource(with selectedAsset: StellarAsset?, excluding: StellarAsset? = nil) {
         guard let account = self.stellarAccount else { return }
 
         let selectedFromAsset = selectedAsset ?? account.assets.first
         let fromDataSource = TradePickerDataSource(assets: account.assets,
                                                    selected: selectedFromAsset,
-                                                   excluding: nil)
+                                                   excluding: excluding)
         fromDataSource.delegate = self
 
         self.tradeFromPickerView.dataSource = fromDataSource
@@ -297,21 +297,25 @@ extension TradeViewController: TradePickerDataSourceDelegate {
         tradeFromTextField.text = ""
         tradeToTextField.text = ""
 
-        guard let lastSelectedToAsset = toAsset, let lastSelectedFromAsset = fromAsset else {
+        guard var lastToAsset = toAsset, let lastFromAsset = fromAsset, let account = self.stellarAccount else {
             return
         }
 
         if pickerView == tradeFromPickerView {
-            buildFromDataSource(with: asset)
-            buildToDataSource(with: nil)
+            if asset == lastToAsset, let newAsset = firstAssetExcluding(asset, in: account) {
+                lastToAsset = newAsset
+            }
 
-            reselectItem(in: toDataSource, picker: tradeToPickerView, lastAsset: lastSelectedToAsset)
+            buildFromDataSource(with: asset)
+            buildToDataSource(with: lastToAsset)
+
+            reselectItem(in: toDataSource, picker: tradeToPickerView, lastAsset: lastToAsset)
             setTradeSelectors()
         } else {
-            buildFromDataSource(with: nil)
+            buildFromDataSource(with: lastFromAsset)
             buildToDataSource(with: asset)
 
-            reselectItem(in: fromDataSource, picker: tradeFromPickerView, lastAsset: lastSelectedFromAsset)
+            reselectItem(in: fromDataSource, picker: tradeFromPickerView, lastAsset: lastFromAsset)
             setTradeSelectors()
         }
 


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects the behaviour of the trade selectors. The rules are as folllows:
* All assets should be available in the 'from' list, at all times
* All assets excluding the currently selected 'from' asset should be in the 'to' list.
* When you select any item in the 'to' list, the 'from' option is not modified.
* When you select any item in the 'from' list, the 'to' option is not modified.
   * _Unless_ it's the current 'to' item. In that case, the first asset in the 'to' list is selected.

## Screenshot
![fixed](https://user-images.githubusercontent.com/728690/48680227-187ffd00-eb67-11e8-9904-4affca23e071.gif)