### PR TITLE
[FIX] Show Transaction Details immediately when cell is tapped

### DIFF
--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
@@ -197,6 +197,7 @@ extension ApplicationCoordinator: StellarIndexingServiceDelegate {
     func finishedIndexing(_ service: StellarIndexingService) {
         print("Indexing finished!")
         indexingViewController?.update(with: 1, error: nil)
+        transactionViewController?.requestData()
     }
 
     func errorIndexing(_ service: StellarIndexingService, error: Error?) {

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -222,5 +222,4 @@
 "OPERATION_OPTIONS_SET_HOMEDOMAIN_DESCRIPTION" = "Home domain set to %@";
 "OPERATION_OPTIONS_SET_SIGNER_DESCRIPTION" = "%@ signer %@ with weight %@";
 
-"TRANSACTIONS_INDEXING_TITLE" = "Indexing Transactions";
-"TRANSACTIONS_INDEXING_MESSAGE" = "Transactions are still being indexed. Once completed, you will be able to see the details for this transaction.";
+"LOADING_TRANSACTION" = "Loading Transaction...";


### PR DESCRIPTION
## Priority
High

## Description
This PR updates the view controller to immediately push the `TransactionDetailsViewController` onto the view stack even before indexing is finished. It then responds to the `indexingFinished()` delegate callback to update the view.

## Screenshot
![fixed](https://user-images.githubusercontent.com/728690/48730534-a8c24e80-ec08-11e8-9850-5ec493b20367.gif)

## Notes
After the first time transactions details are viewed and indexed, there is no loading time for other rows.