### PR TITLE
[FIX] Trade transaction details

### DIFF
--- a/BlockEQ/AppDelegate.swift
+++ b/BlockEQ/AppDelegate.swift
@@ -15,6 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     let container = WrapperVC()
+    let core = StellarCoreService(with: .production)
     let onboardingCoordinator = OnboardingCoordinator()
     var appCoordinator = ApplicationCoordinator()
     var authenticationCoordinator: AuthenticationCoordinator?
@@ -29,6 +30,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         onboardingCoordinator.delegate = self
         appCoordinator.delegate = self
 
+        onboardingCoordinator.core = self.core
+
         if !KeychainHelper.isExistingInstance {
             onboardingContainer = true
             container.moveToViewController(onboardingCoordinator.navController,
@@ -36,7 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                            animated: false,
                                            completion: nil)
         } else {
-            appCoordinator.core = StellarCoreService(with: .production)
+            appCoordinator.core = self.core
 
             onboardingContainer = false
             container.moveToViewController(appCoordinator.tabController,

--- a/BlockEQ/Coordinators/AddressCoordinator.swift
+++ b/BlockEQ/Coordinators/AddressCoordinator.swift
@@ -19,11 +19,7 @@ final class AddressResolver {
     private var mappedContacts: [String: LocalContact] = [:]
 
     static func lookup(address: StellarAddress) -> AddressType {
-        if let _: LocalContact = self.resolve(address: address) {
-            return .contact
-        } else {
-            return .exchange
-        }
+        return .exchange
     }
 
     static func resolve(address: StellarAddress) -> LocalContact? {

--- a/BlockEQ/Coordinators/OnboardingCoordinator.swift
+++ b/BlockEQ/Coordinators/OnboardingCoordinator.swift
@@ -21,13 +21,11 @@ final class OnboardingCoordinator {
 
     weak var delegate: OnboardingCoordinatorDelegate?
     var authenticationCoordinator: AuthenticationCoordinator?
-    var core: StellarCoreService
+    var core: StellarCoreService!
 
     init() {
         navController = AppNavigationController(rootViewController: launchViewController)
         navController.navigationBar.prefersLargeTitles = true
-
-        core = StellarCoreService(with: .production)
 
         verificationViewController.delegate = self
         launchViewController.delegate = self

--- a/BlockEQ/Data Sources/ContactsDataSource.swift
+++ b/BlockEQ/Data Sources/ContactsDataSource.swift
@@ -69,7 +69,7 @@ final class ContactsDataSource: NSObject {
                 let name = "\(contact.givenName) \(contact.familyName)"
                 var stellarEmail = ""
                 for emailAddress in contact.emailAddresses where emailAddress.value.contains(suffix) {
-                    stellarEmail = emailAddress.value as String
+                    stellarEmail = emailAddress.value.replacingOccurrences(of: suffix, with: "") as String
                 }
 
                 let localContact = LocalContact(identifier: contact.identifier, name: name, address: stellarEmail)

--- a/BlockEQ/Data Sources/TransactionDetailsDataSource.swift
+++ b/BlockEQ/Data Sources/TransactionDetailsDataSource.swift
@@ -15,8 +15,8 @@ final class TransactionDetailsDataSource: NSObject {
     var sectionStates: [Int: SectionState] = [
         0: (collapsed: false, itemCount: 0),
         1: (collapsed: false, itemCount: 1),
-        2: (collapsed: true, itemCount: 5),
-        3: (collapsed: true, itemCount: 3)
+        2: (collapsed: true, itemCount: 0),
+        3: (collapsed: true, itemCount: 0)
     ]
 
     weak var headerDelegate: TransactionDetailsSectionHeaderDelegate?

--- a/BlockEQ/Data Sources/WalletDataSource.swift
+++ b/BlockEQ/Data Sources/WalletDataSource.swift
@@ -68,6 +68,8 @@ extension WalletDataSource: UITableViewDataSource {
             cell.update(with: asset, effect: effect)
         }
 
+        cell.selectionStyle = effect.type == .tradeEffect ? .none : .default
+
         return cell
     }
 }

--- a/BlockEQ/Objects/StellarAddress+Extensions.swift
+++ b/BlockEQ/Objects/StellarAddress+Extensions.swift
@@ -12,6 +12,7 @@ extension StellarAddress {
     enum Suffix: String, RawRepresentable {
         case contactAddress = ".publicaddress@blockeq.com"
     }
+
     static func from(contactAddress: String) -> StellarAddress? {
         let stripped = contactAddress.replacingOccurrences(of: Suffix.contactAddress.rawValue, with: "")
         return StellarAddress(stripped)

--- a/BlockEQ/View Controllers/Transactions/TransactionDetailsViewController.swift
+++ b/BlockEQ/View Controllers/Transactions/TransactionDetailsViewController.swift
@@ -50,6 +50,7 @@ final class TransactionDetailsViewController: UIViewController {
         collectionView.delegate = self
         collectionView.dataSource = dataSource
         collectionView.allowsSelection = true
+        collectionView.alwaysBounceVertical = true
         collectionView.registerHeader(type: TransactionDetailsBasicHeader.self)
         collectionView.registerHeader(type: TransactionDetailsSectionHeader.self)
         collectionView.registerCell(type: TransactionDetailsCell.self)
@@ -65,13 +66,13 @@ final class TransactionDetailsViewController: UIViewController {
     }
 
     func showHud() {
-        let hud = MBProgressHUD.showAdded(to: UIApplication.shared.keyWindow!, animated: true)
+        let hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         hud.label.text = "LOADING_TRANSACTION".localized()
         hud.mode = .indeterminate
     }
 
     func hideHud() {
-        MBProgressHUD.hide(for: UIApplication.shared.keyWindow!, animated: true)
+        MBProgressHUD.hide(for: self.view, animated: true)
     }
 
     func requestData() {

--- a/BlockEQ/View Controllers/Wallet/WalletViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/WalletViewController.swift
@@ -87,6 +87,7 @@ class WalletViewController: UIViewController {
         tableViewHeaderLeftLabel.textColor = Colors.darkGrayTransparent
         tableViewHeaderRightLabel.textColor = Colors.darkGrayTransparent
         tableView?.backgroundColor = Colors.lightBackground
+        tableView?.separatorStyle = .none
     }
 
     @IBAction func selectBalance() {
@@ -172,7 +173,7 @@ extension WalletViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        guard let effect = self.dataSource?.effects[indexPath.row] else { return }
+        guard let effect = self.dataSource?.effects[indexPath.row], effect.type != .tradeEffect else { return }
         delegate?.selectedEffect(self, effect: effect)
     }
 }

--- a/BlockEQ/View Controllers/Wallet/WalletViewController.xib
+++ b/BlockEQ/View Controllers/Wallet/WalletViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/BlockEQ/Views/Cells/TransactionHistoryCell.swift
+++ b/BlockEQ/Views/Cells/TransactionHistoryCell.swift
@@ -29,5 +29,8 @@ class TransactionHistoryCell: UITableViewCell, ReusableView, NibLoadableView {
         dateLabel.text = effect.formattedDate
         activityLabel.text = effect.formattedDescription(asset: asset)
         transactionDisplayView.backgroundColor = effect.color
+
+        accessoryType = effect.type == .tradeEffect ? .none : .disclosureIndicator
+        contentView.bottomBorder(with: UIColor(red: 0.957, green: 0.957, blue: 0.957, alpha: 1.000), width: 1)
     }
 }

--- a/StellarAccountService/Operations/Account/FetchOperationsOperation.swift
+++ b/StellarAccountService/Operations/Account/FetchOperationsOperation.swift
@@ -41,13 +41,6 @@ final class FetchAccountOperationsOperation: AsyncOperation {
                                          limit: recordCount) { operationResponse in
             switch operationResponse {
             case .success(let operationResponse):
-                /*
-                 ManageOfferOperationResponse
-                 PaymentOperationResponse
-                 ChangeTrustOperationResponse
-                 SetOptionsOperationResponse
-                 AccountCreatedOperationResponse
-                 */
                 let operations = operationResponse.records.map { StellarOperation($0) }
                 self.result = Result.success(operations)
             case .failure(let error):

--- a/StellarAccountService/Operations/Account/FetchTransactionsOperation.swift
+++ b/StellarAccountService/Operations/Account/FetchTransactionsOperation.swift
@@ -11,21 +11,23 @@ import stellarsdk
 final class FetchTransactionsOperation: AsyncOperation {
     typealias SuccessCompletion = ([StellarTransaction]) -> Void
 
+    static let defaultRecordCount: Int = 200
+
     let horizon: StellarSDK
     let accountId: String
-    let limit: Int
+    let recordCount: Int?
     let completion: SuccessCompletion
     let failure: ErrorCompletion?
     var result: Result<[StellarTransaction]> = Result.failure(AsyncOperationError.responseUnset)
 
     init(horizon: StellarSDK,
          accountId: String,
-         limit: Int = 200,
+         limit: Int? = FetchTransactionsOperation.defaultRecordCount,
          completion: @escaping SuccessCompletion,
          failure: ErrorCompletion? = nil) {
         self.horizon = horizon
         self.accountId = accountId
-        self.limit = limit
+        self.recordCount = limit
         self.completion = completion
         self.failure = failure
     }
@@ -36,7 +38,7 @@ final class FetchTransactionsOperation: AsyncOperation {
         horizon.transactions.getTransactions(forAccount: accountId,
                                              from: nil,
                                              order: .descending,
-                                             limit: self.limit) { resp in
+                                             limit: self.recordCount) { resp in
             switch resp {
             case .success(let response):
                 let transactions = response.records

--- a/StellarAccountService/Services/StellarIndexingService.swift
+++ b/StellarAccountService/Services/StellarIndexingService.swift
@@ -165,12 +165,15 @@ public final class StellarIndexingService: StellarIndexingServiceProtocol {
             return firstNodeIsntInputNode && firstNodeIsDifferentType && secondNodeIsDifferentType
         }
 
+        var possibleNodes: [AnyDataNode?] = []
+
         for edge in incidentEdges.enumerated() {
             let destinationNode = edge.element.second
-            return self.traverse(for: destinationNode, edgeList: filteredEdges)
+            let subSearch = self.traverse(for: destinationNode, edgeList: filteredEdges)
+            possibleNodes.append(subSearch)
         }
 
-        return nil
+        return possibleNodes.compactMap { $0 }.first
     }
 }
 


### PR DESCRIPTION
## Priority
High

## Description
This PR fixes issues surrounding not being able to view the details of certain trade transactions. 

Because some trades don't affect the source account the user is viewing (depending on the trade, the `source account` affects the other account traded with), it's impossible for us to know how to connect the effects to an operation, to finally find the transaction to display. As a result, we have to disable viewing the details of trade transactions that we won't be able to resolve.

Trade effects are *not* selectable anymore, and will not highlight when tapped.

This PR also corrects:
* Always allowing bouncing on `UICollectionView` despite no scroll view content
* Not being able to navigate back from the transaction details screen when loading is in progress
* Improved edge indexing algorithm for when a transaction has multiple operations 

## Screenshot
<img width="545" alt="screen shot 2018-11-21 at 10 52 57 pm" src="https://user-images.githubusercontent.com/728690/48880849-3906bc00-ede0-11e8-83df-64cb803f0029.png">
<img width="545" alt="screen shot 2018-11-21 at 9 46 03 pm" src="https://user-images.githubusercontent.com/728690/48880856-3c9a4300-ede0-11e8-801d-6b1ef4e11427.png">

## Notes
Additional context can be found on this [StackOverflow post](https://stellar.stackexchange.com/questions/1929/why-are-some-operations-missing-when-i-query-operations-by-account)