### PR TITLE
[FEATURE] Network Reachability wrapper class

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		C55458FC2124BB1B00032699 /* AuthenticatingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55458FB2124BB1B00032699 /* AuthenticatingViewController.swift */; };
 		C55660492165D30C00DDAAA5 /* QRMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55660482165D30C00DDAAA5 /* QRMap.swift */; };
 		C564059F219DC1900084CD5E /* Diagnostic+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C564059E219DC1900084CD5E /* Diagnostic+Extensions.swift */; };
+		C5681BB921A779AB00ACEB21 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5681BB821A779AB00ACEB21 /* Reachability.swift */; };
 		C57053E4219F34B400E6B69E /* IndexingViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C57053E3219F34B400E6B69E /* IndexingViewController.xib */; };
 		C57053E6219F357300E6B69E /* IndexingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57053E5219F357300E6B69E /* IndexingViewController.swift */; };
 		C57A8540217814EF0048A6B5 /* TransactionDetailsSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = C57A853F217814EF0048A6B5 /* TransactionDetailsSectionHeader.xib */; };
@@ -328,6 +329,7 @@
 		C55458FB2124BB1B00032699 /* AuthenticatingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatingViewController.swift; sourceTree = "<group>"; };
 		C55660482165D30C00DDAAA5 /* QRMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRMap.swift; sourceTree = "<group>"; };
 		C564059E219DC1900084CD5E /* Diagnostic+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diagnostic+Extensions.swift"; sourceTree = "<group>"; };
+		C5681BB821A779AB00ACEB21 /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		C57053E3219F34B400E6B69E /* IndexingViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IndexingViewController.xib; sourceTree = "<group>"; };
 		C57053E5219F357300E6B69E /* IndexingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexingViewController.swift; sourceTree = "<group>"; };
 		C57A853F217814EF0048A6B5 /* TransactionDetailsSectionHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TransactionDetailsSectionHeader.xib; sourceTree = "<group>"; };
@@ -861,6 +863,7 @@
 				C55660482165D30C00DDAAA5 /* QRMap.swift */,
 				C524DFCA2167CFE40068D111 /* AutoFillHelper.swift */,
 				C524DFCE2167F1AB0068D111 /* AppleAutoFillProvider.swift */,
+				C5681BB821A779AB00ACEB21 /* Reachability.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1339,6 +1342,7 @@
 				C5E8595020AFF09800B77289 /* OnboardingCoordinator.swift in Sources */,
 				C499756621129D2D00E2299C /* TrustedPartiesViewController.swift in Sources */,
 				C5E8594920AFB45E00B77289 /* ContainerViewController.swift in Sources */,
+				C5681BB921A779AB00ACEB21 /* Reachability.swift in Sources */,
 				C439A22F211B6FDC0025C047 /* P2PTransactionViewController.swift in Sources */,
 				C5D8CAC62180D809009F8624 /* AddressCoordinator.swift in Sources */,
 				EC0B19262054BC3B0052802C /* AppNavigationController.swift in Sources */,

--- a/BlockEQ/Utils/Reachability.swift
+++ b/BlockEQ/Utils/Reachability.swift
@@ -1,0 +1,138 @@
+//
+//  ConnectionMonitoring.swift
+//  BlockEQ
+//
+//  Created by Nick DiZazzo on 2018-11-22.
+//  Copyright © 2018 BlockEQ. All rights reserved.
+//
+
+import Network
+import Alamofire
+
+protocol ConnectionStateObservable: AnyObject {
+    func connectionChanged(to state: Reachability.Connection)
+}
+
+protocol ConnectionMonitoring: AnyObject {
+    var delegate: ConnectionStateObservable? { get set }
+
+    func start()
+    func stop()
+}
+
+final class Reachability: ConnectionMonitoring {
+    enum Connection {
+        case available(ConnectionType)
+        case none
+    }
+
+    enum ConnectionType {
+        case wifi
+        case cellular
+        case wired
+        case other
+    }
+
+    let monitor: ConnectionMonitoring?
+
+    var delegate: ConnectionStateObservable? {
+        set { monitor?.delegate = newValue }
+        get { return monitor?.delegate }
+    }
+
+    init() {
+        if #available(iOS 12.0, *) {
+            monitor = NetworkMonitor()
+        } else {
+            monitor = AlamofireReachabilityWrapper()
+        }
+    }
+
+    func start() {
+        monitor?.start()
+    }
+
+    func stop() {
+        monitor?.stop()
+    }
+}
+
+extension Reachability.ConnectionType {
+    @available (iOS 12.0, *)
+    init(interfaceType: NWInterface.InterfaceType) {
+        switch interfaceType {
+        case .cellular: self = .cellular
+        case .wifi: self = .wifi
+        case .wiredEthernet: self = .wired
+        default: self = .other
+        }
+    }
+}
+
+extension Reachability.ConnectionType {
+    init(connectionType: NetworkReachabilityManager.ConnectionType) {
+        switch connectionType {
+        case .ethernetOrWiFi: self = .wifi
+        case .wwan: self = .cellular
+        }
+    }
+}
+
+@available(iOS 12.0, *)
+final class NetworkMonitor: ConnectionMonitoring {
+    let pathMonitor = NWPathMonitor()
+    let dispatchQueue = DispatchQueue.main
+
+    weak var delegate: ConnectionStateObservable?
+
+    init() {
+        pathMonitor.pathUpdateHandler = { [unowned self] path in
+            switch path.status {
+            case .satisfied:
+                let type = Reachability.ConnectionType(interfaceType: path.availableInterfaces.first!.type)
+                self.delegate?.connectionChanged(to: .available(type))
+            default:
+                self.delegate?.connectionChanged(to: .none)
+            }
+        }
+    }
+
+    func start() {
+        pathMonitor.start(queue: dispatchQueue)
+    }
+
+    func stop() {
+        pathMonitor.cancel()
+    }
+}
+
+final class AlamofireReachabilityWrapper: ConnectionMonitoring {
+    weak var delegate: ConnectionStateObservable?
+    let reachability: NetworkReachabilityManager
+
+    init() {
+        guard let nrManager = NetworkReachabilityManager() else {
+            fatalError("Unable to monitor local network interface")
+        }
+
+        reachability = nrManager
+
+        nrManager.listener = { [unowned self] status in
+            switch status {
+            case .reachable(let connectionType):
+                let type = Reachability.ConnectionType(connectionType: connectionType)
+                self.delegate?.connectionChanged(to: .available(type))
+            default:
+                self.delegate?.connectionChanged(to: .none)
+            }
+        }
+    }
+
+    func start() {
+        reachability.startListening()
+    }
+
+    func stop() {
+        reachability.stopListening()
+    }
+}


### PR DESCRIPTION
## Priority
Normal

## Description
This PR implements an iOS 11 and iOS 12 wrapper class that detects changes in network connectivity.

In [WWDC Session 715](https://developer.apple.com/videos/play/wwdc2018/715/), Apple strongly recommended moving away from `SCNetworkReachability`, where possible.

This class begins the transition for this by providing a simple wrapped interface to reachability, that switches depending on platform support for `NWPathMonitor`

## Screenshot
N/A

## Notes
Any additional notes, implications, caveats...