### PR TITLE
[FEATURE] Recovery mnemonic passphrase

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		C55660492165D30C00DDAAA5 /* QRMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55660482165D30C00DDAAA5 /* QRMap.swift */; };
 		C564059F219DC1900084CD5E /* Diagnostic+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C564059E219DC1900084CD5E /* Diagnostic+Extensions.swift */; };
 		C5681BB921A779AB00ACEB21 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5681BB821A779AB00ACEB21 /* Reachability.swift */; };
+		C5681BBB21A8B9BD00ACEB21 /* UIViewController+AdvancedSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5681BBA21A8B9BD00ACEB21 /* UIViewController+AdvancedSecurity.swift */; };
 		C57053E4219F34B400E6B69E /* IndexingViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C57053E3219F34B400E6B69E /* IndexingViewController.xib */; };
 		C57053E6219F357300E6B69E /* IndexingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57053E5219F357300E6B69E /* IndexingViewController.swift */; };
 		C57A8540217814EF0048A6B5 /* TransactionDetailsSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = C57A853F217814EF0048A6B5 /* TransactionDetailsSectionHeader.xib */; };
@@ -330,6 +331,7 @@
 		C55660482165D30C00DDAAA5 /* QRMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRMap.swift; sourceTree = "<group>"; };
 		C564059E219DC1900084CD5E /* Diagnostic+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diagnostic+Extensions.swift"; sourceTree = "<group>"; };
 		C5681BB821A779AB00ACEB21 /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
+		C5681BBA21A8B9BD00ACEB21 /* UIViewController+AdvancedSecurity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AdvancedSecurity.swift"; sourceTree = "<group>"; };
 		C57053E3219F34B400E6B69E /* IndexingViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IndexingViewController.xib; sourceTree = "<group>"; };
 		C57053E5219F357300E6B69E /* IndexingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexingViewController.swift; sourceTree = "<group>"; };
 		C57A853F217814EF0048A6B5 /* TransactionDetailsSectionHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TransactionDetailsSectionHeader.xib; sourceTree = "<group>"; };
@@ -844,6 +846,7 @@
 				C54EFE4921798668005FA6D3 /* UIView+Layer.swift */,
 				C53E62872199E667006BF2F1 /* Alamofire+JSONEncoding.swift */,
 				C53E629C219B41FF006BF2F1 /* UIStackView+Extensions.swift */,
+				C5681BBA21A8B9BD00ACEB21 /* UIViewController+AdvancedSecurity.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1315,6 +1318,7 @@
 				EC4F660020C8CF0C0036293D /* String+Date.swift in Sources */,
 				C54EFE432179043B005FA6D3 /* TransactionDetailsBasicHeader.swift in Sources */,
 				C5BED3762162A81C00BEE464 /* Exchange.swift in Sources */,
+				C5681BBB21A8B9BD00ACEB21 /* UIViewController+AdvancedSecurity.swift in Sources */,
 				ECD3A352207D2CE5000609A0 /* WalletItemActivateCell.swift in Sources */,
 				C53E62862199DC94006BF2F1 /* SendDiagnosticOperation.swift in Sources */,
 				C499755F211297BF00E2299C /* P2PCoordinator.swift in Sources */,

--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
@@ -129,27 +129,17 @@ extension ApplicationCoordinator: SettingsDelegate {
     }
 
     func presentMimicAccount() {
-        let alert = UIAlertController(title: "Account", message: "Enter Account ID to mimic", preferredStyle: .alert)
-        alert.addTextField { field in
-            field.placeholder = "Account ID"
-        }
+        guard let viewController = self.wrappingNavController else { return }
 
-        let mimicAction = UIAlertAction(title: "Mimic", style: .default) { _ in
+        UIAlertController.prompt(title: "Account", message: "Enter Account ID to mimic", handler: { controller in
             #if DEBUG
-            if let accountId = alert.textFields![0].text {
+            if let accountId = controller.textFields![0].text {
                 KeychainHelper.save(accountId: accountId)
                 self.core?.accountService.overrideWithAccount(id: accountId)
                 self.core?.accountService.update()
             }
             #endif
-        }
-
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
-
-        alert.addAction(cancelAction)
-        alert.addAction(mimicAction)
-
-        wrappingNavController?.present(alert, animated: true, completion: nil)
+        }, presentingViewController: viewController, placeholder: "Account ID")
     }
 
     func displayApplicationInfo() {

--- a/BlockEQ/Extensions/UIAlertController+Prompts.swift
+++ b/BlockEQ/Extensions/UIAlertController+Prompts.swift
@@ -14,4 +14,27 @@ extension UIAlertController {
 
         presentingViewController.present(controller, animated: true, completion: nil)
     }
+
+    static func prompt(title: String,
+                       message: String?,
+                       handler: @escaping (UIAlertController) -> Void,
+                       presentingViewController: UIViewController,
+                       placeholder: String? = nil,
+                       okText: String? = "GENERIC_OK_TEXT".localized(),
+                       cancelText: String? = "CANCEL_ACTION".localized()
+                       ) {
+        let controller = UIAlertController.init(title: title, message: message, preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: cancelText, style: .cancel, handler: nil)
+        let okAction = UIAlertAction(title: okText, style: .default, handler: { _ in
+            handler(controller)
+        })
+
+        controller.addAction(okAction)
+        controller.addAction(cancelAction)
+        controller.addTextField { field in
+            field.placeholder = placeholder
+        }
+
+        presentingViewController.present(controller, animated: true, completion: nil)
+    }
 }

--- a/BlockEQ/Extensions/UIViewController+AdvancedSecurity.swift
+++ b/BlockEQ/Extensions/UIViewController+AdvancedSecurity.swift
@@ -1,0 +1,83 @@
+//
+//  UIViewController+AdvancedSecurity.swift
+//  BlockEQ
+//
+//  Created by Nick DiZazzo on 2018-11-23.
+//  Copyright © 2018 BlockEQ. All rights reserved.
+//
+
+import StellarAccountService
+
+protocol PassphrasePromptable: AnyObject {
+    var mnemonicPassphrase: StellarMnemonicPassphrase? { get set }
+    var passphraseButton: UIButton { get }
+}
+
+extension PassphrasePromptable where Self: UIViewController {
+    func styleAdvancedSecurity() {
+        passphraseButton.setTitle("ADVANCED_SECURITY_TITLE".localized(), for: .normal)
+        passphraseButton.titleLabel?.font = UIFont.systemFont(ofSize: 11, weight: .regular)
+        passphraseButton.setTitleColor(Colors.darkGrayTransparent, for: .normal)
+    }
+
+    func passphrasePrompt(confirm: Bool, completion: @escaping (StellarMnemonicPassphrase?) -> Void) {
+        let handler: (UIAlertController) -> Void = { controller in
+            let passphrase = StellarMnemonicPassphrase(controller.textFields?[0].text)
+            completion(passphrase)
+        }
+
+        let title = confirm ? "CONFIRM_PASSPHRASE_TITLE".localized() : "MNEMONIC_PASSPHRASE_TITLE".localized()
+        let message = confirm ? "CONFIRM_PASSPHRASE_MESSAGE".localized() : "MNEMONIC_PASSPHRASE_MESSAGE".localized()
+
+        UIAlertController.prompt(title: title,
+                                 message: message,
+                                 handler: handler,
+                                 presentingViewController: self,
+                                 placeholder: "ENTER_PASSPHRASE_PLACEHOLDER".localized())
+    }
+
+    func mismatchedPrompt() {
+        UIAlertController.simpleAlert(title: "MISMATCHED_PASSPHRASE_TITLE".localized(),
+                                      message: "MISMATCHED_PASSPHRASE_MESSAGE".localized(),
+                                      presentingViewController: self)
+    }
+
+    func updatePassphraseSet(with phrase: StellarMnemonicPassphrase ) {
+        passphraseButton.setTitle("PASSPHRASE_SET".localized(), for: .normal)
+        self.mnemonicPassphrase = phrase
+    }
+
+    func clearPassphrase() {
+        passphraseButton.setTitle("ADVANCED_SECURITY_TITLE".localized(), for: .normal)
+        self.mnemonicPassphrase = nil
+    }
+
+    func setPassphrase(with phrase: StellarMnemonicPassphrase?) {
+        guard let passphrase = phrase else {
+            clearPassphrase()
+            return
+        }
+
+        if let original = self.mnemonicPassphrase, original == passphrase {
+            updatePassphraseSet(with: passphrase)
+        } else if let original = self.mnemonicPassphrase, original != passphrase {
+            clearPassphrase()
+            mismatchedPrompt()
+        } else {
+            let confirmationCallback: (StellarMnemonicPassphrase?) -> Void = { string in
+                self.setPassphrase(with: string)
+            }
+
+            self.mnemonicPassphrase = passphrase
+            self.passphrasePrompt(confirm: true, completion: confirmationCallback)
+        }
+    }
+}
+
+extension MnemonicViewController: PassphrasePromptable {
+    var passphraseButton: UIButton { return self.advancedSecurityButton }
+}
+
+extension VerificationViewController: PassphrasePromptable {
+    var passphraseButton: UIButton { return self.advancedSecurityButton }
+}

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -62,6 +62,13 @@
 "CREATE_MNEMONIC_TWENTYFOUR" = "Use a 24-word recovery phrase";
 "RECOVER_WALLET" = "Recover Wallet";
 "REENTER_PHRASE" = "Re-enter Your Phrase";
+"MNEMONIC_PASSPHRASE_TITLE" = "Mnemonic Passphrase";
+"MNEMONIC_PASSPHRASE_MESSAGE" = "Enter a passphrase to protect your mnemonic";
+"CONFIRM_PASSPHRASE_TITLE" = "Confirm Passphrase";
+"CONFIRM_PASSPHRASE_MESSAGE" = "Please confirm your passphrase";
+
+"ENTER_PASSPHRASE_PLACEHOLDER" = "Enter Passphrase";
+"PASSPHRASE_SET" = "Mnemonic passphrase has been set";
 
 "RECOVER_SECRET_SEED" = "Recover with Stellar secret key";
 "RECOVER_MNEMONIC" = "Recover with mnemonic";
@@ -226,3 +233,8 @@
 "LOADING_TRANSACTION" = "Loading Transaction...";
 "SENDING_DIAGNOSTIC" = "Sending Diagnostic...";
 "FAILED_DIAGNOSTIC" = "Failed";
+
+"CONFIRMED_SECRET_TITLE" = "I have written it down";
+"ADVANCED_SECURITY_TITLE" = "Advanced Security";
+"MISMATCHED_PASSPHRASE_TITLE" = "Mismatched Phrase";
+"MISMATCHED_PASSPHRASE_MESSAGE" = "Your passphrase was not set because they didn't match. Please try again.";

--- a/BlockEQ/View Controllers/Wallet/MnemonicViewController.xib
+++ b/BlockEQ/View Controllers/Wallet/MnemonicViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,6 +13,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MnemonicViewController" customModule="BlockEQ" customModuleProvider="target">
             <connections>
                 <outlet property="activityIndicator" destination="beH-3n-Zlu" id="OZQ-he-uzf"/>
+                <outlet property="advancedSecurityButton" destination="ade-cp-0Fg" id="kha-QP-gj3"/>
                 <outlet property="confirmationButton" destination="PsE-ef-7Q4" id="F97-e5-EWc"/>
                 <outlet property="holderView" destination="3Jg-1T-pTn" id="1Um-5F-tGS"/>
                 <outlet property="mnemonicHolderView" destination="C6e-qd-eOl" id="nz5-ef-9IQ"/>
@@ -28,6 +29,15 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Jg-1T-pTn">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                     <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please write down and safely store this phrase. It's the ONLY WAY to retrieve your wallet." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="osg-Wz-f6c">
+                            <rect key="frame" x="16" y="30" width="288" height="40"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="40" id="6WP-Zy-66e"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C6e-qd-eOl">
                             <rect key="frame" x="16" y="85" width="288" height="405"/>
                             <subviews>
@@ -45,15 +55,13 @@
                                 <constraint firstItem="beH-3n-Zlu" firstAttribute="top" secondItem="C6e-qd-eOl" secondAttribute="top" constant="20" id="WYB-fb-uze"/>
                             </constraints>
                         </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please write down and safely store this phrase. It's the ONLY WAY to retrieve your wallet." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="osg-Wz-f6c">
-                            <rect key="frame" x="16" y="30" width="288" height="40"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="40" id="6WP-Zy-66e"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ade-cp-0Fg" userLabel="Advanced Security Button">
+                            <rect key="frame" x="16" y="445" width="288" height="30"/>
+                            <state key="normal" title="Advanced Security"/>
+                            <connections>
+                                <action selector="selectedAdvancedSecurity:" destination="-1" eventType="touchUpInside" id="2jR-JJ-k36"/>
+                            </connections>
+                        </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PsE-ef-7Q4" customClass="AppButton" customModule="BlockEQ" customModuleProvider="target">
                             <rect key="frame" x="16" y="500" width="288" height="48"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -79,12 +87,15 @@
                         <constraint firstAttribute="trailing" secondItem="PsE-ef-7Q4" secondAttribute="trailing" constant="16" id="0Vl-oW-S2s"/>
                         <constraint firstItem="C6e-qd-eOl" firstAttribute="top" secondItem="osg-Wz-f6c" secondAttribute="bottom" constant="15" id="44L-ps-jkF"/>
                         <constraint firstAttribute="trailing" secondItem="C6e-qd-eOl" secondAttribute="trailing" constant="16" id="FGz-43-ceE"/>
+                        <constraint firstItem="PsE-ef-7Q4" firstAttribute="top" secondItem="ade-cp-0Fg" secondAttribute="bottom" constant="25" id="MLm-Va-Vnk"/>
                         <constraint firstItem="C6e-qd-eOl" firstAttribute="leading" secondItem="3Jg-1T-pTn" secondAttribute="leading" constant="16" id="Ofa-fU-Eby"/>
+                        <constraint firstItem="ade-cp-0Fg" firstAttribute="leading" secondItem="PsE-ef-7Q4" secondAttribute="leading" id="PH2-r2-LF1"/>
                         <constraint firstItem="osg-Wz-f6c" firstAttribute="top" secondItem="3Jg-1T-pTn" secondAttribute="top" constant="30" id="StX-UF-ueb"/>
                         <constraint firstAttribute="bottom" secondItem="PsE-ef-7Q4" secondAttribute="bottom" constant="20" id="WMA-Oj-2kc"/>
                         <constraint firstItem="PsE-ef-7Q4" firstAttribute="top" secondItem="C6e-qd-eOl" secondAttribute="bottom" constant="10" id="b5F-nD-DJ7"/>
                         <constraint firstItem="osg-Wz-f6c" firstAttribute="leading" secondItem="3Jg-1T-pTn" secondAttribute="leading" constant="16" id="hp3-zb-58Z"/>
                         <constraint firstAttribute="trailing" secondItem="osg-Wz-f6c" secondAttribute="trailing" constant="16" id="imB-Jr-5Se"/>
+                        <constraint firstItem="ade-cp-0Fg" firstAttribute="trailing" secondItem="PsE-ef-7Q4" secondAttribute="trailing" id="ixX-1x-dmZ"/>
                         <constraint firstItem="PsE-ef-7Q4" firstAttribute="leading" secondItem="3Jg-1T-pTn" secondAttribute="leading" constant="16" id="uPE-hX-M5H"/>
                     </constraints>
                 </view>

--- a/BlockEQ/View Controllers/Wallet/VerificationViewController.xib
+++ b/BlockEQ/View Controllers/Wallet/VerificationViewController.xib
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VerificationViewController" customModule="BlockEQ" customModuleProvider="target">
             <connections>
+                <outlet property="advancedSecurityButton" destination="Qvp-6Y-ujm" id="FRf-VQ-bSN"/>
                 <outlet property="collectionView" destination="uar-6Q-8gN" id="kUn-rl-saH"/>
                 <outlet property="progressView" destination="Uzi-m7-v4Y" id="YRr-GK-FXZ"/>
                 <outlet property="progressViewWidthConstraint" destination="iCg-9p-Tvw" id="qJJ-bb-QQy"/>
@@ -108,7 +109,7 @@
                     </constraints>
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QNY-cd-5bI" customClass="AppButton" customModule="BlockEQ" customModuleProvider="target">
-                    <rect key="frame" x="16" y="318" width="343" height="48"/>
+                    <rect key="frame" x="16" y="362" width="343" height="48"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="48" id="sNe-X3-8CN"/>
                     </constraints>
@@ -123,6 +124,13 @@
                         <action selector="nextButtonSelected" destination="-1" eventType="touchUpInside" id="cK0-jK-aOj"/>
                     </connections>
                 </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qvp-6Y-ujm" userLabel="Advanced Security Button">
+                    <rect key="frame" x="16" y="317" width="343" height="30"/>
+                    <state key="normal" title="Advanced Security"/>
+                    <connections>
+                        <action selector="advancedSecuritySelected:" destination="-1" eventType="touchUpInside" id="Vfy-B8-xgH"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
@@ -134,9 +142,12 @@
                 <constraint firstItem="Smi-Lv-1zE" firstAttribute="top" secondItem="1RZ-No-B37" secondAttribute="bottom" id="Fz5-sH-MW8"/>
                 <constraint firstItem="QNY-cd-5bI" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="HD7-Ny-ghs"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="1RZ-No-B37" secondAttribute="trailing" id="SeI-5X-qW8"/>
-                <constraint firstItem="QNY-cd-5bI" firstAttribute="top" secondItem="Smi-Lv-1zE" secondAttribute="bottom" constant="15" id="ZYF-Cs-lAd"/>
+                <constraint firstItem="Qvp-6Y-ujm" firstAttribute="trailing" secondItem="QNY-cd-5bI" secondAttribute="trailing" id="XLE-Jx-IBC"/>
                 <constraint firstItem="hA1-Ss-YK5" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="aKN-eX-VST"/>
+                <constraint firstItem="QNY-cd-5bI" firstAttribute="top" secondItem="Qvp-6Y-ujm" secondAttribute="bottom" constant="15" id="fpV-FY-vzv"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="QNY-cd-5bI" secondAttribute="trailing" constant="16" id="g1r-eS-r8n"/>
+                <constraint firstItem="Qvp-6Y-ujm" firstAttribute="leading" secondItem="QNY-cd-5bI" secondAttribute="leading" id="hBV-yu-ezA"/>
+                <constraint firstItem="Qvp-6Y-ujm" firstAttribute="top" secondItem="1RZ-No-B37" secondAttribute="bottom" constant="15" id="q7o-65-WgL"/>
                 <constraint firstItem="1RZ-No-B37" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="zWX-7s-we5"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>

--- a/StellarAccountService.xcodeproj/project.pbxproj
+++ b/StellarAccountService.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		C5144212217ED9CE006C44F4 /* PostPaymentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5144211217ED9CE006C44F4 /* PostPaymentOperation.swift */; };
 		C5144214217EDBCF006C44F4 /* ChangeTrustOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5144213217EDBCF006C44F4 /* ChangeTrustOperation.swift */; };
 		C5144216217EDC71006C44F4 /* ChangeP2PTrustOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5144215217EDC71006C44F4 /* ChangeP2PTrustOperation.swift */; };
+		C558412821AC459C0090D463 /* StellarMnemonicPassphrase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C558412721AC459C0090D463 /* StellarMnemonicPassphrase.swift */; };
+		C558412A21AC49BB0090D463 /* StellarMnemonicPassphraseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C558412921AC49BB0090D463 /* StellarMnemonicPassphraseTests.swift */; };
 		C58898B5218766CB0057D787 /* StellarTradeOfferData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58898B4218766CB0057D787 /* StellarTradeOfferData.swift */; };
 		C58898B7218795B90057D787 /* StellarP2PService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58898B6218795B90057D787 /* StellarP2PService.swift */; };
 		C593DFD6218BFEDD00FA01DD /* StellarOrderbookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C593DFD5218BFEDD00FA01DD /* StellarOrderbookTests.swift */; };
@@ -137,6 +139,8 @@
 		C5144211217ED9CE006C44F4 /* PostPaymentOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPaymentOperation.swift; sourceTree = "<group>"; };
 		C5144213217EDBCF006C44F4 /* ChangeTrustOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeTrustOperation.swift; sourceTree = "<group>"; };
 		C5144215217EDC71006C44F4 /* ChangeP2PTrustOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeP2PTrustOperation.swift; sourceTree = "<group>"; };
+		C558412721AC459C0090D463 /* StellarMnemonicPassphrase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StellarMnemonicPassphrase.swift; sourceTree = "<group>"; };
+		C558412921AC49BB0090D463 /* StellarMnemonicPassphraseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StellarMnemonicPassphraseTests.swift; sourceTree = "<group>"; };
 		C58898B4218766CB0057D787 /* StellarTradeOfferData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StellarTradeOfferData.swift; sourceTree = "<group>"; };
 		C58898B6218795B90057D787 /* StellarP2PService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StellarP2PService.swift; sourceTree = "<group>"; };
 		C593DFD5218BFEDD00FA01DD /* StellarOrderbookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StellarOrderbookTests.swift; sourceTree = "<group>"; };
@@ -386,6 +390,7 @@
 				C5D8CAD8218264BC009F8624 /* StellarAssetPair.swift */,
 				C58898B4218766CB0057D787 /* StellarTradeOfferData.swift */,
 				C5114DA5219217F300C88E4F /* StellarDataGraph.swift */,
+				C558412721AC459C0090D463 /* StellarMnemonicPassphrase.swift */,
 			);
 			path = Objects;
 			sourceTree = "<group>";
@@ -426,6 +431,7 @@
 				C593DFE1218C065400FA01DD /* StellarOfferTests.swift */,
 				C5FE7580218BCE280090E372 /* StellarAssetPairTests.swift */,
 				C593DFDF218C04D500FA01DD /* StellarTradeOfferDataTests.swift */,
+				C558412921AC49BB0090D463 /* StellarMnemonicPassphraseTests.swift */,
 			);
 			path = Objects;
 			sourceTree = "<group>";
@@ -743,6 +749,7 @@
 				C5F1CA06217A9C3E001C847A /* UpdateInflationOperation.swift in Sources */,
 				C512E6A3217FCCB000D1AC74 /* Result.swift in Sources */,
 				C51441EE217D7481006C44F4 /* StellarConfig.swift in Sources */,
+				C558412821AC459C0090D463 /* StellarMnemonicPassphrase.swift in Sources */,
 				C5FE7578218AAECB0090E372 /* StellarIndexingService.swift in Sources */,
 				C51441E5217AEE17006C44F4 /* FetchOffersOperation.swift in Sources */,
 				C5F1C9EF217A7BCE001C847A /* StellarAddress.swift in Sources */,
@@ -764,6 +771,7 @@
 				C593DFF2218C0F2C00FA01DD /* StellarAccountServiceOperationTests.swift in Sources */,
 				C593DFF0218C0E5A00FA01DD /* StellarAccountTests.swift in Sources */,
 				C593DFD6218BFEDD00FA01DD /* StellarOrderbookTests.swift in Sources */,
+				C558412A21AC49BB0090D463 /* StellarMnemonicPassphraseTests.swift in Sources */,
 				C593DFE0218C04D500FA01DD /* StellarTradeOfferDataTests.swift in Sources */,
 				C5FE7585218BD1B10090E372 /* StellarEffectTests.swift in Sources */,
 				C5FE7581218BCE280090E372 /* StellarAssetPairTests.swift in Sources */,

--- a/StellarAccountService/Objects/StellarMnemonicPassphrase.swift
+++ b/StellarAccountService/Objects/StellarMnemonicPassphrase.swift
@@ -1,0 +1,45 @@
+//
+//  StellarMnemonicPassphrase.swift
+//  StellarAccountService
+//
+//  Created by Nick DiZazzo on 2018-11-26.
+//  Copyright © 2018 BlockEQ. All rights reserved.
+//
+
+import Foundation
+
+public struct StellarMnemonicPassphrase {
+    static var invalidCharacters: CharacterSet {
+        return CharacterSet.alphanumerics.union(CharacterSet.whitespaces).inverted
+    }
+
+    public let string: String
+
+    public init?(_ passphrase: String?) {
+        guard let phrase = passphrase, !phrase.isEmpty else { return nil }
+
+        guard !StellarMnemonicPassphrase.containsInvalidCharacters(passphrase: phrase) else { return nil }
+
+        guard !StellarMnemonicPassphrase.containsOnlySpacingCharacters(passphrase: phrase) else { return nil }
+
+        string = phrase
+    }
+
+    static func containsInvalidCharacters(passphrase: String) -> Bool {
+        if passphrase.rangeOfCharacter(from: StellarMnemonicPassphrase.invalidCharacters) != nil {
+            return true
+        }
+
+        return false
+    }
+
+    static func containsOnlySpacingCharacters(passphrase: String) -> Bool {
+        if passphrase.rangeOfCharacter(from: CharacterSet.whitespaces.inverted) == nil {
+            return true
+        }
+
+        return false
+    }
+}
+
+extension StellarMnemonicPassphrase: Equatable { }

--- a/StellarAccountService/Services/StellarAccountService.swift
+++ b/StellarAccountService/Services/StellarAccountService.swift
@@ -89,10 +89,14 @@ extension StellarAccountService {
     }
 
     // Creates a new account with the provided mnemonic
-    public func initializeAccount(with mnemonic: StellarRecoveryMnemonic, index: Int = 0) throws {
+    public func initializeAccount(with mnemonic: StellarRecoveryMnemonic,
+                                  passphrase: StellarMnemonicPassphrase?,
+                                  index: Int = 0) throws {
         guard account == nil else { throw ServiceError.alreadyInitialized }
 
-        guard let keyPair = try? Wallet.createKeyPair(mnemonic: mnemonic.string, passphrase: nil, index: index) else {
+        guard let keyPair = try? Wallet.createKeyPair(mnemonic: mnemonic.string,
+                                                      passphrase: passphrase?.string,
+                                                      index: index) else {
             throw ServiceError.keypairCreation
         }
 

--- a/StellarAccountServiceTests/Objects/StellarMnemonicPassphraseTests.swift
+++ b/StellarAccountServiceTests/Objects/StellarMnemonicPassphraseTests.swift
@@ -1,0 +1,73 @@
+//
+//  StellarMnemonicPassphraseTests.swift
+//  StellarAccountServiceTests
+//
+//  Created by Nick DiZazzo on 2018-11-26.
+//  Copyright © 2018 BlockEQ. All rights reserved.
+//
+
+import XCTest
+@testable import StellarAccountService
+
+class StellarMnemonicPassphraseTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testMnemonicPassphraseWithSpacesIsValid() {
+        let passphrase = StellarMnemonicPassphrase("I have spaces and ascii characters")
+        XCTAssertNotNil(passphrase)
+    }
+
+    func testBlankMnemonicPassphraseIsInvalid() {
+        let passphrase1 = StellarMnemonicPassphrase("")
+        let passphrase2 = StellarMnemonicPassphrase(nil)
+        XCTAssertNil(passphrase1)
+        XCTAssertNil(passphrase2)
+    }
+
+    func testLanguagePassphraseCases() {
+        let validPhrases = [
+            "एक हिंदी वाक्य",
+            "日本語文",
+            "Una frase en español",
+            "한국어 문장",
+            "Một câu tiếng việt", "جملة عربية" // right to left on its own line messes with keyboard navigation
+        ]
+
+        let phrases = validPhrases.compactMap { StellarMnemonicPassphrase($0) }
+
+        XCTAssertEqual(phrases.count, validPhrases.count)
+    }
+
+    func testOnlySpacingPhraseFails() {
+        let invalidPhrases = [
+            "       ",
+            "\t\t\t\t",
+            "\t\n      ",
+            "       "
+        ]
+
+        let phrases = invalidPhrases.compactMap { StellarMnemonicPassphrase($0) }
+        XCTAssertEqual(phrases.count, 0)
+    }
+
+    func testNonAlphanumericPassphraseIsInvalid() {
+        let invalidPhrases = [
+            "hypenated-english-phrase",
+            "👋🏻",
+            "No work {",
+            "No work ]",
+            "No work ,",
+            "No work !",
+            "No work $"
+        ]
+
+        let phrases = invalidPhrases.compactMap { StellarMnemonicPassphrase($0) }
+        XCTAssertEqual(phrases.count, 0)
+    }
+}


### PR DESCRIPTION
## Priority
High

## Description
This PR adds support for the mnemonic passphrase when creating and restoring a wallet.

Like our other wallets, it presents two prompts that ask the user to enter then confirm their mnemonic passphrase.

## Screenshot
![create](https://user-images.githubusercontent.com/728690/49031731-cb101b00-f178-11e8-9911-9ef00a7d4615.gif)
![recover](https://user-images.githubusercontent.com/728690/49031732-cd727500-f178-11e8-8fb5-47e147e3c7b1.gif)
