### PR TITLE
[FIX] Missing Trade effects for non-native assets in effect list

### DIFF
--- a/BlockEQ/Data Sources/WalletDataSource.swift
+++ b/BlockEQ/Data Sources/WalletDataSource.swift
@@ -41,7 +41,11 @@ final class WalletDataSource: NSObject {
         self.index = account.assets.firstIndex(of: asset) ?? 0
         self.account = account
         self.effects = account.effects
-            .filter { $0.asset == asset && WalletDataSource.supportedEffects.contains($0.type) }
+            .filter {
+                let isBaseAsset = $0.asset == asset && WalletDataSource.supportedEffects.contains($0.type)
+                let isPairAsset = $0.assetPair.buying == asset || $0.assetPair.selling == asset
+                return isBaseAsset || isPairAsset
+            }
             .sorted(by: { (first, second) -> Bool in first.createdAt > second.createdAt })
     }
 }


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects behaviour after the refactor that filtered out any effect whose base type didn't match what the wallet was currently viewing.

Since trades also might reference a non-native token, we have to include the buying / selling asset of the asset pair in the filtering logic in order to not exclude them.

## Screenshot
<img width="545" alt="screen shot 2018-11-26 at 1 46 42 pm" src="https://user-images.githubusercontent.com/728690/49035543-1deed000-f183-11e8-9a6f-94b8cdcde3e1.png">