### PR TITLE
[FIX] Adds a prompt that notifies the user when a disallowed passphrase was entered

### DIFF
--- a/BlockEQ/Extensions/UIViewController+AdvancedSecurity.swift
+++ b/BlockEQ/Extensions/UIViewController+AdvancedSecurity.swift
@@ -42,6 +42,12 @@ extension PassphrasePromptable where Self: UIViewController {
                                       presentingViewController: self)
     }
 
+    func invalidPrompt() {
+        UIAlertController.simpleAlert(title: "INVALID_PASSPHRASE_TITLE".localized(),
+                                      message: "INVALID_PASSPHRASE_MESSAGE".localized(),
+                                      presentingViewController: self)
+    }
+
     func updatePassphraseSet(with phrase: StellarMnemonicPassphrase ) {
         passphraseButton.setTitle("PASSPHRASE_SET".localized(), for: .normal)
         self.mnemonicPassphrase = phrase
@@ -55,6 +61,7 @@ extension PassphrasePromptable where Self: UIViewController {
     func setPassphrase(with phrase: StellarMnemonicPassphrase?) {
         guard let passphrase = phrase else {
             clearPassphrase()
+            invalidPrompt()
             return
         }
 

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -238,3 +238,5 @@
 "ADVANCED_SECURITY_TITLE" = "Advanced Security";
 "MISMATCHED_PASSPHRASE_TITLE" = "Mismatched Phrase";
 "MISMATCHED_PASSPHRASE_MESSAGE" = "Your passphrase was not set because they didn't match. Please try again.";
+"INVALID_PASSPHRASE_TITLE" = "Invalid Phrase";
+"INVALID_PASSPHRASE_MESSAGE" = "That passphrase contains one or more disallowed characters. Please try again.";


### PR DESCRIPTION
## Priority
Normal

## Description
This PR adds a notification when a passphrase could not successfully be created from their input text.

## Screenshot
<img width="545" alt="screen shot 2018-11-26 at 2 54 17 pm" src="https://user-images.githubusercontent.com/728690/49038580-5abec500-f18b-11e8-992c-6c44b2450e74.png">
<img width="545" alt="screen shot 2018-11-26 at 2 54 21 pm" src="https://user-images.githubusercontent.com/728690/49038582-5beff200-f18b-11e8-97db-812c91cd935d.png">