### PR TITLE
[FIX] Conceals mnemonic passphrase during text entry

### DIFF
--- a/BlockEQ/Extensions/UIAlertController+Prompts.swift
+++ b/BlockEQ/Extensions/UIAlertController+Prompts.swift
@@ -21,7 +21,8 @@ extension UIAlertController {
                        presentingViewController: UIViewController,
                        placeholder: String? = nil,
                        okText: String? = "GENERIC_OK_TEXT".localized(),
-                       cancelText: String? = "CANCEL_ACTION".localized()
+                       cancelText: String? = "CANCEL_ACTION".localized(),
+                       secureText: Bool = false
                        ) {
         let controller = UIAlertController.init(title: title, message: message, preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: cancelText, style: .cancel, handler: nil)
@@ -33,6 +34,9 @@ extension UIAlertController {
         controller.addAction(cancelAction)
         controller.addTextField { field in
             field.placeholder = placeholder
+            field.autocorrectionType = .no
+            field.autocapitalizationType = .none
+            field.isSecureTextEntry = secureText
         }
 
         presentingViewController.present(controller, animated: true, completion: nil)

--- a/BlockEQ/Extensions/UIViewController+AdvancedSecurity.swift
+++ b/BlockEQ/Extensions/UIViewController+AdvancedSecurity.swift
@@ -33,7 +33,8 @@ extension PassphrasePromptable where Self: UIViewController {
                                  message: message,
                                  handler: handler,
                                  presentingViewController: self,
-                                 placeholder: "ENTER_PASSPHRASE_PLACEHOLDER".localized())
+                                 placeholder: "ENTER_PASSPHRASE_PLACEHOLDER".localized(),
+                                 secureText: true)
     }
 
     func mismatchedPrompt() {


### PR DESCRIPTION
## Priority
Normal

## Description
This PR conceals the text entry when typing a mnemonic passphrase.

## Screenshot
<img width="545" alt="screen shot 2018-11-28 at 4 53 55 pm" src="https://user-images.githubusercontent.com/728690/49184789-3ea75900-f32e-11e8-9811-e9c3454e0bc3.png">

## Notes
Any additional notes, implications, caveats...
