### PR TITLE
[FIX] Adds ability to hide the advanced security button

### DIFF
--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
@@ -197,9 +197,7 @@ extension ApplicationCoordinator: SettingsDelegate {
 
     func displayMnemonic() {
         let mnemonic = core?.accountService.accountMnemonic()
-        let mnemonicViewController = MnemonicViewController(mnemonic: mnemonic,
-                                                            shouldSetPin: false,
-                                                            hideConfirmation: true)
+        let mnemonicViewController = MnemonicViewController(mnemonic: mnemonic, hideConfirmation: true)
 
         wrappingNavController?.pushViewController(mnemonicViewController, animated: true)
     }

--- a/BlockEQ/Coordinators/OnboardingCoordinator.swift
+++ b/BlockEQ/Coordinators/OnboardingCoordinator.swift
@@ -55,7 +55,7 @@ extension OnboardingCoordinator: LaunchViewControllerDelegate {
             return
         }
 
-        let mnemonicVC = MnemonicViewController(mnemonic: mnemonic, shouldSetPin: false, hideConfirmation: false)
+        let mnemonicVC = MnemonicViewController(mnemonic: mnemonic, hideConfirmation: false, advancedSecurity: true)
         mnemonicVC.delegate = self
 
         self.mnemonicViewController = mnemonicVC

--- a/BlockEQ/View Controllers/Wallet/MnemonicViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/MnemonicViewController.swift
@@ -27,6 +27,7 @@ class MnemonicViewController: UIViewController {
 
     var mnemonic: StellarRecoveryMnemonic?
     var hideConfirmation: Bool = false
+    var hideAdvancedSecurity: Bool = true
     var mnemonicPassphrase: StellarMnemonicPassphrase?
 
     required init?(coder aDecoder: NSCoder) {
@@ -34,9 +35,10 @@ class MnemonicViewController: UIViewController {
         self.mnemonic = StellarRecoveryMnemonic(Wallet.generate24WordMnemonic())
     }
 
-    init(mnemonic: StellarRecoveryMnemonic?, shouldSetPin: Bool, hideConfirmation: Bool = false) {
+    init(mnemonic: StellarRecoveryMnemonic?, hideConfirmation: Bool = false, advancedSecurity: Bool = false) {
         super.init(nibName: String(describing: MnemonicViewController.self), bundle: nil)
         self.hideConfirmation = hideConfirmation
+        self.hideAdvancedSecurity = !advancedSecurity
         self.mnemonic = mnemonic
     }
 
@@ -70,6 +72,8 @@ class MnemonicViewController: UIViewController {
 
         let navButton = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(saveToKeychain(_:)))
         navigationItem.rightBarButtonItem = navButton
+
+        advancedSecurityButton.isHidden = hideAdvancedSecurity
 
         styleAdvancedSecurity()
     }


### PR DESCRIPTION
## Priority
Normal

## Description
This PR updates the `MnemonicViewController` to be able to conceal the 'advanced security' button. This avoids inadvertently seeing it when viewing the secret mnemonic phrase.

## Screenshot
N/A

## Notes
Any additional notes, implications, caveats...
