### PR TITLE
[FIX] Removes the success prompt from saving a mnemonic to the keychain

### DIFF
--- a/BlockEQ/View Controllers/Wallet/MnemonicViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/MnemonicViewController.swift
@@ -126,16 +126,25 @@ extension MnemonicViewController {
 
     @objc func saveToKeychain(_ sender: UIBarButtonItem) {
         guard let mnemonic = self.mnemonic?.string else { return }
-        AutoFillHelper.provider = AppleAutoFillProvider()
+
+        let keychainProvider = AppleAutoFillProvider()
+        AutoFillHelper.provider = keychainProvider
+
         AutoFillHelper.save(mnemonic: mnemonic) { error in
             if let error = error {
                 UIAlertController.simpleAlert(title: "ERROR_TITLE".localized(),
                                               message: error.localizedDescription,
                                               presentingViewController: self)
             } else {
-                UIAlertController.simpleAlert(title: "SAVED".localized(),
-                                              message: "MNEMONIC_STORED".localized(),
-                                              presentingViewController: self)
+//                This has been removed to not scare users since the error case is never triggered even if the user
+//                selects "don't allow" in the OS prompt.
+//
+//                A radar bug has been filed with Apple for this.
+
+//
+//                UIAlertController.simpleAlert(title: "SAVED".localized(),
+//                                              message: "MNEMONIC_STORED".localized(),
+//                                              presentingViewController: self)
             }
         }
     }


### PR DESCRIPTION
## Priority
Normal

## Description
This PR temporarily removes the prompt indicating successful storage of the user's secret in the keychain.

## Screenshot
<img width="545" alt="screen shot 2018-11-28 at 5 44 57 pm" src="https://user-images.githubusercontent.com/728690/49228925-6f34d480-f3ba-11e8-840f-adaa7b19e3ac.png">

## Notes
Until Apple's `SecAddSharedWebCredential` sends an error back in the callback when tapping 'Don't Allow', this will need to stay disabled.