### PR TITLE
[FIX] Recovering with secret seed & mnemonic with passphrase

### DIFF
--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
@@ -208,7 +208,8 @@ extension ApplicationCoordinator: SettingsDelegate {
         if let seed = core?.accountService.accountSecretSeed() {
             viewController = SecretSeedViewController(seed)
         } else if let mnemonic = core?.accountService.accountMnemonic() {
-            viewController = SecretSeedViewController(mnemonic: mnemonic)
+            let passphrase = core?.accountService.accountPassphrase()
+            viewController = SecretSeedViewController(mnemonic: mnemonic, passphrase: passphrase)
         } else {
             return
         }

--- a/BlockEQ/View Controllers/Keys/SecretSeedViewController.swift
+++ b/BlockEQ/View Controllers/Keys/SecretSeedViewController.swift
@@ -19,12 +19,15 @@ final class SecretSeedViewController: UIViewController {
 
     let blurEffect = UIBlurEffect(style: .light)
     let concealingView = UIVisualEffectView(effect: nil)
-    var mnemonic: String?
+    var mnemonic: StellarRecoveryMnemonic?
+    var passphrase: StellarMnemonicPassphrase?
     var seed: String?
     var revealed: Bool = false
 
-    init(mnemonic: StellarRecoveryMnemonic?) {
-        self.mnemonic = mnemonic?.string
+    init(mnemonic: StellarRecoveryMnemonic?, passphrase: StellarMnemonicPassphrase?) {
+        self.mnemonic = mnemonic
+        self.passphrase = passphrase
+
         super.init(nibName: String(describing: SecretSeedViewController.self), bundle: nil)
     }
 
@@ -143,8 +146,10 @@ final class SecretSeedViewController: UIViewController {
         }
 
         DispatchQueue.global(qos: .userInitiated).async {
+            let phrase = self.passphrase?.string
+
             if let mnemonic = self.mnemonic,
-                let keyPair = try? Wallet.createKeyPair(mnemonic: mnemonic, passphrase: nil, index: 0),
+                let keyPair = try? Wallet.createKeyPair(mnemonic: mnemonic.string, passphrase: phrase, index: 0),
                 let secretSeed = keyPair.secretSeed {
                 DispatchQueue.main.async {
                     self.setQRCode(QRMap(with: secretSeed, correctionLevel: .full), text: secretSeed)

--- a/StellarAccountService/Services/StellarAccountService.swift
+++ b/StellarAccountService/Services/StellarAccountService.swift
@@ -101,7 +101,7 @@ extension StellarAccountService {
         }
 
         self.startup(keyPair: keyPair)
-        self.secretManager?.store(mnemonic: mnemonic)
+        self.secretManager?.store(mnemonic: mnemonic, passphrase: passphrase)
     }
 
     // Creates a new account with the provided seed
@@ -183,6 +183,10 @@ extension StellarAccountService {
 extension StellarAccountService {
     public func accountMnemonic() -> StellarRecoveryMnemonic? {
         return StellarRecoveryMnemonic(secretManager?.mnemonic)
+    }
+
+    public func accountPassphrase() -> StellarMnemonicPassphrase? {
+        return StellarMnemonicPassphrase(secretManager?.passphrase)
     }
 
     public func accountSecretSeed() -> StellarSeed? {

--- a/StellarAccountService/Utilities/SecretManager.swift
+++ b/StellarAccountService/Utilities/SecretManager.swift
@@ -14,6 +14,7 @@ public final class SecretManager: SecretManagerProtocol {
     static let privateSeedKeyFormat = "%@_privateKey"
     static let secretSeedKeyFormat = "%@_secretSeed"
     static let mnemonicKeyFormat = "%@_mnemonic"
+    static let passphraseKeyFormat = "%@_passphrase"
 
     let accountId: String
 
@@ -33,10 +34,15 @@ public final class SecretManager: SecretManagerProtocol {
         return String(format: SecretManager.mnemonicKeyFormat, accountId)
     }
 
+    private static func passphraseKey(for accountId: String) -> String {
+        return String(format: SecretManager.passphraseKeyFormat, accountId)
+    }
+
     var publicKeyKey: String { return SecretManager.publicKeyKey(for: self.accountId) }
     var privateKeyKey: String { return SecretManager.privateKeyKey(for: self.accountId) }
     var secretSeedKey: String { return SecretManager.secretSeedKey(for: self.accountId) }
     var mnemonicKey: String { return SecretManager.mnemonicKey(for: self.accountId) }
+    var passphraseKey: String { return SecretManager.passphraseKey(for: self.accountId) }
 
     init(for account: String) {
         self.accountId = account
@@ -76,6 +82,10 @@ public final class SecretManager: SecretManagerProtocol {
         return KeychainSwift().get(mnemonicKey)
     }
 
+    var passphrase: String? {
+        return KeychainSwift().get(passphraseKey)
+    }
+
     internal func store(keyPair: KeyPair) {
         let pubKey = keyPair.publicKey
         guard let privKey = keyPair.privateKey else { return }
@@ -83,8 +93,11 @@ public final class SecretManager: SecretManagerProtocol {
         self.store(pub: pubKey, priv: privKey)
     }
 
-    internal func store(mnemonic: StellarRecoveryMnemonic) {
+    internal func store(mnemonic: StellarRecoveryMnemonic, passphrase: StellarMnemonicPassphrase? = nil) {
         KeychainSwift().set(mnemonic.string, forKey: mnemonicKey)
+
+        guard let phrase = passphrase?.string else { return }
+        KeychainSwift().set(phrase, forKey: passphraseKey)
     }
 
     internal func store(seed: StellarSeed) {
@@ -101,5 +114,6 @@ public final class SecretManager: SecretManagerProtocol {
         KeychainSwift().delete(publicKeyKey)
         KeychainSwift().delete(secretSeedKey)
         KeychainSwift().delete(mnemonicKey)
+        KeychainSwift().delete(passphraseKey)
     }
 }


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects issues when recovering a wallet using the secret seed after generating it with a mnemonic that has a passphrase.

When you generate an account using a mnemonic, secret seed view controller has to re-generate your that in order to display it as a QR code. When the mnemonic was passed in, the passphrase was not being passed in, causing that to derive a completely different Stellar public address.

We now securely store the mnemonic passphrase (in the Secure Enclave) in order to correctly regenerate that secret seed.

## Screenshot
N/A