### PR TITLE
[FIX] Selecting 'Account Created' effect does not load

### DIFF
--- a/BlockEQ/Data Sources/WalletDataSource.swift
+++ b/BlockEQ/Data Sources/WalletDataSource.swift
@@ -26,6 +26,12 @@ final class WalletDataSource: NSObject {
         .accountInflationDestinationUpdated
     ]
 
+    static let supportedDetails: [EffectType] = [
+        .accountCredited,
+        .accountDebited,
+        .accountInflationDestinationUpdated
+    ]
+
     private var index: Int
     var effects: [StellarEffect] = []
     var account: StellarAccount
@@ -73,7 +79,7 @@ extension WalletDataSource: UITableViewDataSource {
             cell.update(with: asset, effect: effect)
         }
 
-        cell.selectionStyle = effect.type == .tradeEffect ? .none : .default
+        cell.selectionStyle = WalletDataSource.supportedDetails.contains(effect.type) ? .default : .none
 
         return cell
     }

--- a/BlockEQ/View Controllers/Wallet/WalletViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/WalletViewController.swift
@@ -173,7 +173,9 @@ extension WalletViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        guard let effect = self.dataSource?.effects[indexPath.row], effect.type != .tradeEffect else { return }
+        guard let effect = self.dataSource?.effects[indexPath.row],
+            WalletDataSource.supportedDetails.contains(effect.type) else { return }
+
         delegate?.selectedEffect(self, effect: effect)
     }
 }

--- a/BlockEQ/Views/Cells/TransactionHistoryCell.swift
+++ b/BlockEQ/Views/Cells/TransactionHistoryCell.swift
@@ -30,7 +30,7 @@ class TransactionHistoryCell: UITableViewCell, ReusableView, NibLoadableView {
         activityLabel.text = effect.formattedDescription(asset: asset)
         transactionDisplayView.backgroundColor = effect.color
 
-        accessoryType = effect.type == .tradeEffect ? .none : .disclosureIndicator
+        accessoryType = WalletDataSource.supportedDetails.contains(effect.type) ? .disclosureIndicator : .none
         contentView.bottomBorder(with: UIColor(red: 0.957, green: 0.957, blue: 0.957, alpha: 1.000), width: 1)
     }
 }


### PR DESCRIPTION
## Priority
Normal

## Description
The account details for "Account Created" will never work because the source account for the transaction will be the account who sent the Lumens to your account. This means when the account transactions are fetched from Horizon, the necessary transaction details will not be sent along with the response.

The solution is to disable details for "Account Created" until we have a more robust data fetching system.

## Screenshot
<img width="545" alt="screen shot 2018-11-29 at 7 10 00 pm" src="https://user-images.githubusercontent.com/728690/49260173-64a22b80-f40a-11e8-9d18-763cac58c058.png">