### PR TITLE
[FIX] Incorrect effects appearing in wallet list for other assets

### DIFF
--- a/BlockEQ/Data Sources/WalletDataSource.swift
+++ b/BlockEQ/Data Sources/WalletDataSource.swift
@@ -47,11 +47,12 @@ final class WalletDataSource: NSObject {
         self.index = account.assets.firstIndex(of: asset) ?? 0
         self.account = account
         self.effects = account.effects
-            .filter {
-                let isSupportedType = WalletDataSource.supportedEffects.contains($0.type)
-                let isBaseAsset = $0.asset == asset
-                let isPairAsset = $0.assetPair.buying == asset || $0.assetPair.selling == asset
-                return isSupportedType && (isBaseAsset || isPairAsset)
+            .filter { currentEffect in
+                let isSupportedType = WalletDataSource.supportedEffects.contains(currentEffect.type)
+                let isBaseAsset = currentEffect.asset == asset
+                let isPairAsset = currentEffect.assetPair.buying == asset || currentEffect.assetPair.selling == asset
+                let isIncludedTrade = currentEffect.type == .tradeEffect && isPairAsset
+                return isSupportedType && (isBaseAsset || isIncludedTrade)
             }
             .sorted(by: { (first, second) -> Bool in first.createdAt > second.createdAt })
     }


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects behaviour introduced in `2.4.0` that allowed trades to show for each of the buying and selling asset. 

Unfortunately, this also included effects for assets which you weren't currently filtering. This is now corrected.

## Screenshot
N/A