### PR TITLE
[FIX] Removes the requirement that secrets are present for accounts in StellarAccountService during initialization

### DIFF
--- a/StellarAccountService/Services/StellarAccountService+Internal.swift
+++ b/StellarAccountService/Services/StellarAccountService+Internal.swift
@@ -10,8 +10,6 @@ import stellarsdk
 
 extension StellarAccountService {
     internal func startup(address: StellarAddress) {
-        guard SecretManager.hasSecrets(for: address.string) else { return }
-
         let stubAccount = StellarAccount(accountId: address.string)
         self.account = stubAccount
 


### PR DESCRIPTION
## Priority
Normal

## Description
This PR removes the requirement that the app has secret keys for the current account. This helps during debugging mode to view wallets as a read-only without private signing keys.

## Screenshot
N/A