### PR TITLE
[FEATURE] Adds support to blur the user's mnemonic words

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		C514420E217ED2B7006C44F4 /* StellarTransaction+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C514420D217ED2B7006C44F4 /* StellarTransaction+Extensions.swift */; };
 		C5144210217ED86F006C44F4 /* FetchExchangesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C514420F217ED86F006C44F4 /* FetchExchangesOperation.swift */; };
 		C5173A8621A4A94800B5272F /* CenteredCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5173A8521A4A94800B5272F /* CenteredCollectionViewFlowLayout.swift */; };
+		C51B6E5C21B9B553001DFEF7 /* UIViewController+Blurrable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51B6E5B21B9B553001DFEF7 /* UIViewController+Blurrable.swift */; };
 		C524DFC92167B6240068D111 /* KeychainHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C524DFC82167B6240068D111 /* KeychainHelperTests.swift */; };
 		C524DFCB2167CFE40068D111 /* AutoFillHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C524DFCA2167CFE40068D111 /* AutoFillHelper.swift */; };
 		C524DFCD2167DF020068D111 /* AutoFillHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C524DFCC2167DF020068D111 /* AutoFillHelperTests.swift */; };
@@ -293,6 +294,7 @@
 		C514420D217ED2B7006C44F4 /* StellarTransaction+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StellarTransaction+Extensions.swift"; sourceTree = "<group>"; };
 		C514420F217ED86F006C44F4 /* FetchExchangesOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchExchangesOperation.swift; sourceTree = "<group>"; };
 		C5173A8521A4A94800B5272F /* CenteredCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenteredCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
+		C51B6E5B21B9B553001DFEF7 /* UIViewController+Blurrable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Blurrable.swift"; sourceTree = "<group>"; };
 		C52186B820C06B8100FF2A76 /* SecurityOptionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityOptionHelper.swift; sourceTree = "<group>"; };
 		C524DFC82167B6240068D111 /* KeychainHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainHelperTests.swift; sourceTree = "<group>"; };
 		C524DFCA2167CFE40068D111 /* AutoFillHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFillHelper.swift; sourceTree = "<group>"; };
@@ -854,6 +856,7 @@
 				C53E629C219B41FF006BF2F1 /* UIStackView+Extensions.swift */,
 				C5681BBA21A8B9BD00ACEB21 /* UIViewController+AdvancedSecurity.swift */,
 				C5B3F9BE21B5C9BA009375AC /* UIViewController+Error.swift */,
+				C51B6E5B21B9B553001DFEF7 /* UIViewController+Blurrable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1331,6 +1334,7 @@
 				C53E62862199DC94006BF2F1 /* SendDiagnosticOperation.swift in Sources */,
 				C499755F211297BF00E2299C /* P2PCoordinator.swift in Sources */,
 				C5114DB7219548AC00C88E4F /* TransactionDetailsDataSource.swift in Sources */,
+				C51B6E5C21B9B553001DFEF7 /* UIViewController+Blurrable.swift in Sources */,
 				C5401D342178005B00A12AC2 /* TransactionDetailsViewController.swift in Sources */,
 				EC2015F720532F4B009A73C8 /* AppButton.swift in Sources */,
 				C5AB413D2090436700096A29 /* UIView+NibLoadableView.swift in Sources */,

--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
@@ -198,9 +198,7 @@ extension ApplicationCoordinator: SettingsDelegate {
     func displayMnemonic() {
         let mnemonic = core?.accountService.accountMnemonic()
         let phrase = core?.accountService.accountPassphrase()
-        let mnemonicViewController = MnemonicViewController(mnemonic: mnemonic,
-                                                            passphrase: phrase,
-                                                            hideConfirmation: true)
+        let mnemonicViewController = MnemonicViewController(mnemonic: mnemonic, passphrase: phrase, mode: .view)
 
         wrappingNavController?.pushViewController(mnemonicViewController, animated: true)
     }

--- a/BlockEQ/Coordinators/OnboardingCoordinator.swift
+++ b/BlockEQ/Coordinators/OnboardingCoordinator.swift
@@ -55,7 +55,7 @@ extension OnboardingCoordinator: LaunchViewControllerDelegate {
             return
         }
 
-        let mnemonicVC = MnemonicViewController(mnemonic: mnemonic, hideConfirmation: false, advancedSecurity: true)
+        let mnemonicVC = MnemonicViewController(mnemonic: mnemonic, mode: .confirm)
         mnemonicVC.delegate = self
 
         self.mnemonicViewController = mnemonicVC

--- a/BlockEQ/Extensions/UIViewController+Blurrable.swift
+++ b/BlockEQ/Extensions/UIViewController+Blurrable.swift
@@ -1,0 +1,53 @@
+//
+//  UIViewController+Blurrable.swift
+//  BlockEQ
+//
+//  Created by Nick DiZazzo on 2018-12-06.
+//  Copyright © 2018 BlockEQ. All rights reserved.
+//
+
+import Foundation
+
+protocol Blurrable: AnyObject {
+    var blurContainerView: UIView? { get }
+    var toggleButton: UIButton? { get }
+    var concealingView: UIVisualEffectView { get }
+    var blurEffect: UIBlurEffect { get }
+    var revealed: Bool { get set }
+
+    func toggleVisibility(revealText: String, concealText: String)
+    func blur(labelText: String, animated: Bool, timeInterval: TimeInterval)
+    func unblur(labelText: String, animated: Bool, timeInterval: TimeInterval)
+}
+
+extension Blurrable where Self: UIViewController {
+    func toggleVisibility(revealText: String, concealText: String) {
+        if revealed {
+            blur(labelText: revealText)
+        } else {
+            unblur(labelText: concealText)
+        }
+
+        revealed.toggle()
+    }
+
+    func blur(labelText: String, animated: Bool = true, timeInterval: TimeInterval = 0.5) {
+        if animated {
+            UIView.animate(withDuration: timeInterval) { self.concealingView.effect = self.blurEffect }
+        } else {
+            concealingView.effect = blurEffect
+        }
+
+        toggleButton?.setTitle(labelText, for: .normal)
+    }
+
+    func unblur(labelText: String, animated: Bool = true, timeInterval: TimeInterval = 0.5) {
+        if animated {
+            UIView.animate(withDuration: timeInterval) { self.concealingView.effect = nil }
+        } else {
+            concealingView.effect = nil
+        }
+
+        toggleButton?.setTitle(labelText, for: .normal)
+    }
+}

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -157,6 +157,8 @@
 "DISPLAY_SECRET_SEED_DESCRIPTION" = "This QR code represents your 56-character Stellar secret key. Please ensure you keep it safe!";
 "REVEAL_SECRET_SEED_INFORMATION" = "Reveal Secret Key";
 "CONCEAL_SECRET_SEED_INFORMATION" = "Conceal Secret Key";
+"REVEAL_MNEMONIC_INFORMATION" = "Reveal Mnemonic";
+"CONCEAL_MNEMONIC_INFORMATION" = "Conceal Mnemonic";
 "SECRET_SEED_PREFIX" = "Seed:";
 "MNEMONIC_PREFIX" = "Mnemonic:";
 "BLOCKEQ_WALLET" = "BlockEQ Wallet";

--- a/BlockEQ/View Controllers/Keys/SecretSeedViewController.xib
+++ b/BlockEQ/View Controllers/Keys/SecretSeedViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -68,11 +68,12 @@
                         <constraint firstItem="Pap-1C-oIT" firstAttribute="leading" secondItem="ZpB-H8-xjt" secondAttribute="leading" id="swD-kh-Qhr"/>
                     </constraints>
                 </view>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HEe-Os-2Qj">
-                    <rect key="frame" x="25" y="602" width="325" height="40"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HEe-Os-2Qj" customClass="AppButton" customModule="BlockEQ" customModuleProvider="target">
+                    <rect key="frame" x="25" y="594" width="325" height="48"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="40" id="KS4-H4-klc"/>
+                        <constraint firstAttribute="height" constant="48" id="KS4-H4-klc"/>
                     </constraints>
+                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
                     <state key="normal" title="Reveal / Conceal"/>
                     <connections>
                         <action selector="selectedToggleButton:" destination="-1" eventType="touchUpInside" id="WFx-rh-dvZ"/>

--- a/BlockEQ/View Controllers/Wallet/MnemonicViewController.xib
+++ b/BlockEQ/View Controllers/Wallet/MnemonicViewController.xib
@@ -54,50 +54,50 @@
                                 <action selector="selectedAdvancedSecurity:" destination="-1" eventType="touchUpInside" id="2jR-JJ-k36"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PsE-ef-7Q4" customClass="AppButton" customModule="BlockEQ" customModuleProvider="target">
-                            <rect key="frame" x="16" y="500" width="288" height="48"/>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="48" id="Ca0-sc-TJA"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
-                            <state key="normal" title="I have written it down">
-                                <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </state>
-                            <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                    <integer key="value" value="5"/>
-                                </userDefinedRuntimeAttribute>
-                            </userDefinedRuntimeAttributes>
-                            <connections>
-                                <action selector="confirmedWrittenDown:" destination="-1" eventType="touchUpInside" id="hc3-e0-KsO"/>
-                            </connections>
-                        </button>
                     </subviews>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="trailing" secondItem="PsE-ef-7Q4" secondAttribute="trailing" constant="16" id="0Vl-oW-S2s"/>
+                        <constraint firstItem="ade-cp-0Fg" firstAttribute="leading" secondItem="7kd-ui-elz" secondAttribute="leading" id="Gt5-aR-dGD"/>
                         <constraint firstItem="7kd-ui-elz" firstAttribute="top" secondItem="osg-Wz-f6c" secondAttribute="bottom" constant="16" id="LgT-YM-f4k"/>
-                        <constraint firstItem="PsE-ef-7Q4" firstAttribute="top" secondItem="ade-cp-0Fg" secondAttribute="bottom" constant="25" id="MLm-Va-Vnk"/>
-                        <constraint firstItem="ade-cp-0Fg" firstAttribute="leading" secondItem="PsE-ef-7Q4" secondAttribute="leading" id="PH2-r2-LF1"/>
+                        <constraint firstAttribute="bottom" secondItem="ade-cp-0Fg" secondAttribute="bottom" constant="93" id="SnM-J9-bhg"/>
                         <constraint firstItem="osg-Wz-f6c" firstAttribute="top" secondItem="3Jg-1T-pTn" secondAttribute="top" constant="30" id="StX-UF-ueb"/>
-                        <constraint firstAttribute="bottom" secondItem="PsE-ef-7Q4" secondAttribute="bottom" constant="20" id="WMA-Oj-2kc"/>
                         <constraint firstItem="osg-Wz-f6c" firstAttribute="leading" secondItem="3Jg-1T-pTn" secondAttribute="leading" constant="16" id="hp3-zb-58Z"/>
                         <constraint firstAttribute="trailing" secondItem="osg-Wz-f6c" secondAttribute="trailing" constant="16" id="imB-Jr-5Se"/>
-                        <constraint firstItem="ade-cp-0Fg" firstAttribute="trailing" secondItem="PsE-ef-7Q4" secondAttribute="trailing" id="ixX-1x-dmZ"/>
                         <constraint firstAttribute="trailing" secondItem="7kd-ui-elz" secondAttribute="trailing" constant="16" id="jzv-HN-K9j"/>
                         <constraint firstItem="7kd-ui-elz" firstAttribute="leading" secondItem="3Jg-1T-pTn" secondAttribute="leading" constant="16" id="otW-t4-8bq"/>
-                        <constraint firstItem="PsE-ef-7Q4" firstAttribute="leading" secondItem="3Jg-1T-pTn" secondAttribute="leading" constant="16" id="uPE-hX-M5H"/>
                         <constraint firstItem="ade-cp-0Fg" firstAttribute="top" secondItem="7kd-ui-elz" secondAttribute="bottom" constant="10" id="v9O-VI-C7h"/>
+                        <constraint firstItem="ade-cp-0Fg" firstAttribute="trailing" secondItem="7kd-ui-elz" secondAttribute="trailing" id="wkO-cI-Bwt"/>
                     </constraints>
                 </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PsE-ef-7Q4" customClass="AppButton" customModule="BlockEQ" customModuleProvider="target">
+                    <rect key="frame" x="16" y="490" width="288" height="48"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="48" id="Ca0-sc-TJA"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                    <state key="normal" title="I have written it down">
+                        <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <integer key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="selectedConfirmation:" destination="-1" eventType="touchUpInside" id="nbt-f3-oRA"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" red="0.96862745098039216" green="0.96862745098039216" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="3Jg-1T-pTn" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="5IZ-u1-1pV"/>
                 <constraint firstItem="3Jg-1T-pTn" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="-20" id="Khc-yH-aSO"/>
+                <constraint firstItem="PsE-ef-7Q4" firstAttribute="leading" secondItem="3Jg-1T-pTn" secondAttribute="leading" constant="16" id="XZu-8y-AyB"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="PsE-ef-7Q4" secondAttribute="bottom" constant="30" id="d9V-pH-aqD"/>
                 <constraint firstItem="3Jg-1T-pTn" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="lb0-s9-wqb"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="3Jg-1T-pTn" secondAttribute="bottom" id="m3l-9K-Aar"/>
+                <constraint firstItem="3Jg-1T-pTn" firstAttribute="trailing" secondItem="PsE-ef-7Q4" secondAttribute="trailing" constant="16" id="ql8-iB-zuf"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="33" y="54"/>


### PR DESCRIPTION
## Priority
Normal

## Description
This PR adds support to blur the user's mnemonic just as it's done for the secret seed. This prevents over-the-shoulder glances if the user is in a public space and navigates into the "view mnemonic" screen.

## Screenshot
![blur](https://user-images.githubusercontent.com/728690/49616442-d6d0be00-f97e-11e8-82c2-3ee312fd8c09.gif)