### PR TITLE
[FIX] Prevents users from adding an asset trustline to their own account address

### DIFF
--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -267,7 +267,7 @@
 
 "UNKNOWN_ERROR_MESSAGE" = "An unknown error has occured. If this issue persists, please contact support.";
 "REQUEST_FAILED_ERROR_MESSAGE" = "Your network connection appears to be offline. Please connect to a Wifi or cellular network to complete this operation.";
-"BAD_REQUEST_ERROR_MESSAGE" = "Bad Request error message";
+"BAD_REQUEST_ERROR_MESSAGE" = "There was an error processing this request. If this issue persists, please contact support.";
 "INVALID_RESPONSE_ERROR_MESSAGE" = "";
 "UNAUTHORIZED_ERROR_MESSAGE" = "";
 "FORBIDDEN_ERROR_MESSAGE" = "";

--- a/BlockEQ/View Controllers/Wallet/AddAssetViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/AddAssetViewController.swift
@@ -62,7 +62,8 @@ class AddAssetViewController: UIViewController {
             return
         }
 
-        guard let issuer = StellarAddress(issuerTextField.text) else {
+        let selfAddress = StellarAddress(KeychainHelper.accountId)
+        guard let issuer = StellarAddress(issuerTextField.text), issuer != selfAddress else {
             issuerTextField.shake()
             return
         }


### PR DESCRIPTION
## Priority
Normal

## Description
This PR addresses an issue where it's possible to add a trust line to your own account. 

There's no case where an issuing address for an asset would want to add a trust line to its self, so we're preventing that action when allowing the user to create trustlines.

Additionally - When you punch in an invalid issuer for an asset + address combination, we display a general error message for any Stellar network error flagged with `bad_request`. 

## Screenshot
![fixed](https://user-images.githubusercontent.com/728690/49831045-e1190080-fd60-11e8-8f20-04ddb9f38c7d.gif)
