### PR TITLE
[FIX] Forces the account information to be refetched when the application becomes active

### DIFF
--- a/BlockEQ/AppDelegate.swift
+++ b/BlockEQ/AppDelegate.swift
@@ -65,6 +65,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         authenticate()
     }
 
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        if !onboardingContainer {
+            appCoordinator.didBecomeActive()
+        }
+    }
+
     func authenticate(_ style: AuthenticationCoordinator.AuthenticationStyle? = nil) {
         guard SecurityOptionHelper.check(.pinOnLaunch) else {
             return

--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
@@ -145,6 +145,14 @@ final class ApplicationCoordinator {
             KeychainHelper.clearStellarSecrets()
         }
     }
+
+    func didBecomeActive() {
+        refreshAccount()
+    }
+
+    func refreshAccount() {
+        core?.accountService.update()
+    }
 }
 
 extension ApplicationCoordinator: TradeHeaderViewDelegate {


### PR DESCRIPTION
## Priority
Normal

## Description
This PR adds support to run tasks in the `ApplicationCoordinator` when the application lifecycle event for becoming active is triggered.

In `ApplicationCoordinator` when the app becomes active, we now trigger a refresh of the account information.

## Screenshot
N/A