### PR TITLE
[FIX] Don't re-initialize AppCoordinator when switching to onboarding in AppDelegate

### DIFF
--- a/BlockEQ/AppDelegate.swift
+++ b/BlockEQ/AppDelegate.swift
@@ -96,10 +96,7 @@ extension AppDelegate: ApplicationCoordinatorDelegate {
         container.moveToViewController(onboardingCoordinator.navController,
                                        fromViewController: appCoordinator.tabController,
                                        animated: true,
-                                       completion: {
-                                        self.appCoordinator = ApplicationCoordinator()
-                                        self.appCoordinator.delegate = self
-        })
+                                       completion: nil)
     }
 }
 


### PR DESCRIPTION
## Priority
Normal

## Description
This PR removes some leftover code that re-initialized the `AppCoordinator` class when failing to enter your PIN after 3 attempts. Since the `AppCoordinator` class isn't optional anymore, this is no longer needed.

## Screenshot
N/A