### PR TITLE
[FIX] Added some checks to prevent an indexing operation to be started multiple times

### DIFF
--- a/StellarHub/Services/StellarIndexingService.swift
+++ b/StellarHub/Services/StellarIndexingService.swift
@@ -68,6 +68,11 @@ public final class IndexingService: IndexingServiceProtocol {
     internal func updateIndex() {
         guard !indexQueue.isSuspended else { return }
 
+        if let existingIndexOperation = indexQueue.operations.first as? NodeIndexingOperation,
+            existingIndexOperation.isExecuting || !existingIndexOperation.isReady {
+            return
+        }
+
         let indexOperation = NodeIndexingOperation(operations: graph.operationNodes,
                                                    effects: graph.effectNodes,
                                                    transactions: graph.transactionNodes)


### PR DESCRIPTION
## Priority
Normal

## Description
This PR adds a bit of logic to prevent multiple indexing operations from getting added to the processing queue. 

This could happen as a result of the `IndexingService` trying to update the index after receiving a callback for each type of object: `StellarOperation`, `StellarTransaction`, and `StellarEffect`.

## Screenshot
N/A

## Notes
* This could happen as a result of updating each type of Stellar object
