### PR TITLE
[FIX] Corrects a crash when viewing transaction details

### DIFF
--- a/BlockEQ/Views/Transactions/TransactionSection.swift
+++ b/BlockEQ/Views/Transactions/TransactionSection.swift
@@ -70,7 +70,7 @@ enum TransactionSection: Int, RawRepresentable {
             basicHeader.rightLabel.text = data
             view = basicHeader
         default:
-            let expandingHeader: TransactionDetailsSectionHeader = collectionView.dequeueFooter(for: index)
+            let expandingHeader: TransactionDetailsSectionHeader = collectionView.dequeueHeader(for: index)
             expandingHeader.collapsed = collapsed
             expandingHeader.headerTitle.text = self.title
             expandingHeader.delegate = delegate


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects a crash that tries to load a section footer instead of a header for transaction details in development builds.

## Screenshot
N/A
