### PR TITLE
[FIX] Corrects InflationViewController behaviour when setting inflation destination

### DIFF
--- a/BlockEQ/Coordinators/AssetCoordinator.swift
+++ b/BlockEQ/Coordinators/AssetCoordinator.swift
@@ -135,6 +135,8 @@ extension AssetCoordinator: AssetActionDelegate {
             let inflationVC = inflationViewController ?? InflationViewController(account: account)
             inflationVC.delegate = self
 
+            self.inflationViewController = inflationVC
+
             assetNavController?.pushViewController(inflationVC, animated: true)
         }
     }
@@ -164,6 +166,21 @@ extension AssetCoordinator: AssetListDelegate {
 extension AssetCoordinator: InflationViewControllerDelegate {
     func updateAccountInflation(_ viewController: InflationViewController, destination: StellarAddress) {
         accountService.setInflationDestination(account: account, address: destination, delegate: self)
+    }
+
+    func dismiss(_ viewController: InflationViewController) {
+        assetNavController?.popViewController(animated: true)
+
+        if let dataSource = delegate?.dataSource() {
+            dataSource.actionDelegate = self
+            dataSource.selectionDelegate = self
+            self.assetListDataSource = dataSource
+
+            assetListViewController?.dataSource = dataSource
+            assetListViewController?.reload()
+        }
+
+        inflationViewController = nil
     }
 }
 

--- a/BlockEQ/View Controllers/Wallet/InflationViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/InflationViewController.swift
@@ -11,6 +11,7 @@ import StellarHub
 
 protocol InflationViewControllerDelegate: AnyObject {
     func updateAccountInflation(_ viewController: InflationViewController, destination: StellarAddress)
+    func dismiss(_ viewController: InflationViewController)
 }
 
 final class InflationViewController: UIViewController {
@@ -94,8 +95,7 @@ extension InflationViewController {
 
     func dismissView() {
         view.endEditing(true)
-
-        navigationController?.dismiss(animated: true, completion: nil)
+        delegate?.dismiss(self)
     }
 }
 


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects behaviour when setting the inflation destination for an account. It was not being dismissed when the action was successful.

## Screenshot
![fix](https://user-images.githubusercontent.com/728690/50912645-9d1d2800-1400-11e9-9297-abc8e99ad7da.gif)