### PR TITLE
[FIX] Sending 100% of an available asset now incorporates network fee

### DIFF
--- a/BlockEQ/View Controllers/Wallet/SendAmountViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/SendAmountViewController.swift
@@ -64,7 +64,7 @@ class SendAmountViewController: UIViewController {
 
         guard let asset = self.currentAsset, let account = accountService.account else { return }
 
-        let availableBalance = account.availableBalance(for: asset).tradeFormattedString
+        let availableBalance = account.availableSendBalance(for: asset).tradeFormattedString
         navigationItem.title = String(format: "TRADE_BALANCE_FORMAT".localized(), availableBalance, asset.shortCode)
     }
 
@@ -155,7 +155,7 @@ class SendAmountViewController: UIViewController {
     func isValidSendAmount(amount: String) -> Bool {
         guard let asset = self.currentAsset, let account = accountService.account else { return false }
 
-        let totalAvailableBalance = account.availableBalance(for: asset)
+        let totalAvailableBalance = account.availableSendBalance(for: asset)
         if let totalSendable = Decimal(string: amount) {
             return totalSendable.isZero ? false : totalSendable <= totalAvailableBalance
         }

--- a/BlockEQ/View Controllers/Wallet/SendViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/SendViewController.swift
@@ -19,33 +19,7 @@ class SendViewController: UIViewController {
     var accountService: AccountManagementService
     var currentAsset: StellarAsset?
 
-    @IBAction func addAmount() {
-        guard let receiver = StellarAddress(sendAddressTextField.text),
-            receiver.string != KeychainHelper.accountId else {
-                sendAddressTextField.shake()
-                return
-        }
 
-        guard let asset = self.currentAsset else { return }
-
-        self.view.endEditing(true)
-
-        let exchange: Exchange? = AddressResolver.resolve(address: receiver)
-        let sendAmountViewController = SendAmountViewController(service: accountService,
-                                                                currentAsset: asset,
-                                                                receiver: receiver,
-                                                                exchangeName: exchange?.name)
-
-        self.navigationController?.pushViewController(sendAmountViewController, animated: true)
-    }
-
-    @IBAction func scanQRCode() {
-        let scanViewController = ScanViewController()
-        scanViewController.delegate = self
-
-        let navigationController = AppNavigationController(rootViewController: scanViewController)
-        present(navigationController, animated: true, completion: nil)
-    }
 
     init(service: AccountManagementService, asset: StellarAsset) {
         self.accountService = service
@@ -95,8 +69,8 @@ class SendViewController: UIViewController {
 
         guard let asset = self.currentAsset, let account = accountService.account else { return }
 
-        let availableBalance = account.availableBalance(for: asset).displayFormattedString
-        navigationItem.title = String(format: "TRADE_BALANCE_FORMAT".localized(), availableBalance, asset.shortCode)
+        let availableSendBalance = account.availableSendBalance(for: asset).displayFormattedString
+        navigationItem.title = String(format: "TRADE_BALANCE_FORMAT".localized(), availableSendBalance, asset.shortCode)
     }
 
     @objc func dismissView() {
@@ -112,6 +86,37 @@ class SendViewController: UIViewController {
 
     func hideHud() {
         MBProgressHUD.hide(for: (navigationController?.view)!, animated: true)
+    }
+}
+
+// MARK: - IBActions
+extension SendViewController {
+    @IBAction func addAmount() {
+        guard let receiver = StellarAddress(sendAddressTextField.text),
+            receiver.string != KeychainHelper.accountId else {
+                sendAddressTextField.shake()
+                return
+        }
+
+        guard let asset = self.currentAsset else { return }
+
+        self.view.endEditing(true)
+
+        let exchange: Exchange? = AddressResolver.resolve(address: receiver)
+        let sendAmountViewController = SendAmountViewController(service: accountService,
+                                                                currentAsset: asset,
+                                                                receiver: receiver,
+                                                                exchangeName: exchange?.name)
+
+        self.navigationController?.pushViewController(sendAmountViewController, animated: true)
+    }
+
+    @IBAction func scanQRCode() {
+        let scanViewController = ScanViewController()
+        scanViewController.delegate = self
+
+        let navigationController = AppNavigationController(rootViewController: scanViewController)
+        present(navigationController, animated: true, completion: nil)
     }
 }
 

--- a/StellarHub/Objects/StellarAccount.swift
+++ b/StellarHub/Objects/StellarAccount.swift
@@ -225,7 +225,7 @@ public final class StellarAccount {
         let availableBalance = self.availableBalance(for: asset)
 
         if asset.isNative {
-            let availableTotal = availableBalance - baseFee - baseReserve
+            let availableTotal = availableBalance - baseFee
             return availableTotal > 0 ? availableTotal : 0
         } else {
             return availableBalance

--- a/StellarHubTests/Objects/StellarAccountTests.swift
+++ b/StellarHubTests/Objects/StellarAccountTests.swift
@@ -319,4 +319,18 @@ class StellarAccountTests: XCTestCase {
         account.outstandingTradeAmounts[asset] = 90
         XCTAssertEqual(account.availableBalance(for: asset, subtractTradeAmounts: false), 100)
     }
+
+    func testAssetAvailableSendBalanceOnlyIncorporatesNetworkFee() {
+        let account = StellarAccount(accountId: "hello")
+        let asset = StellarAsset(assetType: AssetTypeAsString.NATIVE, assetCode: nil, assetIssuer: nil, balance: "100")
+        account.assets[0] = asset
+        XCTAssertEqual(account.availableSendBalance(for: asset), 98.99999)
+    }
+
+    func testAssetAvailableTradeBalanceIncorporatesBaseAndNetworkFee() {
+        let account = StellarAccount(accountId: "hello")
+        let asset = StellarAsset(assetType: AssetTypeAsString.NATIVE, assetCode: nil, assetIssuer: nil, balance: "100")
+        account.assets[0] = asset
+        XCTAssertEqual(account.availableTradeBalance(for: asset), 98.49999)
+    }
 }


### PR DESCRIPTION
## Priority
High

## Description
This PR incorporates the missing network fee when displaying the available balance to the user. It also now does the calculation on behalf of the user when validating the sent amount.

Sending 100% of your available balance for an asset now succeeds, and leaves no residual amounts.

## Screenshot
<img width="545" alt="screen shot 2019-01-09 at 11 39 13 am" src="https://user-images.githubusercontent.com/728690/50914666-0bfc8000-1405-11e9-818b-781a96969da1.png">
