### PR TITLE
[FIX] Corrects usage of content inset instead of section inset in the trading asset datasource

### DIFF
--- a/BlockEQ/Data Sources/TradeAssetListDataSource.swift
+++ b/BlockEQ/Data Sources/TradeAssetListDataSource.swift
@@ -36,10 +36,8 @@ extension TradeAssetListDataSource: UICollectionViewDataSource {
 
         cell.update(with: model, indexPath: indexPath)
 
-        if let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
-            let inset = flowLayout.sectionInset.left + flowLayout.sectionInset.right
-            cell.preferredWidth = collectionView.bounds.width - inset
-        }
+        let inset = collectionView.contentInset.left + collectionView.contentInset.right
+        cell.preferredWidth = collectionView.bounds.width - inset
 
         return cell
     }


### PR DESCRIPTION
## Priority
Normal

## Description
This PR implements a minor fix to use `contentInset` instead of the old method of computing cell widths using `sectionInset` for the `TradeAssetListDataSource`.

## Screenshot
<img width="545" alt="screen shot 2019-01-13 at 4 24 18 pm" src="https://user-images.githubusercontent.com/728690/51090797-d252ae80-174f-11e9-914b-94bb18ad2e0a.png">