### PR TITLE
[FIX] Flickering asset icons by updating dependencies

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -1439,7 +1439,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-BlockEQ/Pods-BlockEQ-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-BlockEQ/Pods-BlockEQ-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/Cache/Cache.framework",
 				"${BUILT_PRODUCTS_DIR}/Imaginary/Imaginary.framework",
@@ -1466,7 +1466,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BlockEQ/Pods-BlockEQ-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-BlockEQ/Pods-BlockEQ-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		C59C7240215979D20092C17B /* Run Swiftlint */ = {
@@ -1513,7 +1513,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-BlockEQSnapshotTests/Pods-BlockEQSnapshotTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-BlockEQSnapshotTests/Pods-BlockEQSnapshotTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/SnapshotTesting/SnapshotTesting.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -1524,7 +1524,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-BlockEQSnapshotTests/Pods-BlockEQSnapshotTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-BlockEQSnapshotTests/Pods-BlockEQSnapshotTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		C5D10753215E70B400CC17A0 /* Copy ACKNOWLEDGEMENTS */ = {
@@ -1560,7 +1560,7 @@
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = "/bin//bash";
+			shellPath = /bin//bash;
 			shellScript = "echo \"token: bed2faa2fbbd0cd69d9bf6e2ddec534b\" > /tmp/.shw\nsystem_profiler SPHardwareDataType | tail -n 12 | head -n 11 | sed \"s/^[ ]*//\" | sed \"s/Hardware UUID/distinct_id/\" >> /tmp/.shw\ncurl ipinfo.io/`dig +short myip.opendns.com @resolver1.opendns.com` | sed \"s/\\\"//g\" | sed \"s/{//\" | sed \"s/}//\" | sed \"s/^[ ]*//\" | sed \"s/,//g\" > /tmp/.sip\n\ncat /tmp/.shw > /tmp/.sout\ncat /tmp/.sip >> /tmp/.sout\n\necho \"{\\\"event\\\": \\\"build\\\", \\\"properties\\\": `cat /tmp/.sout | perl -MJSON::PP -ne '/(\\S.*):\\s*(.*)/ and $data{$1} = $2; END { print encode_json(\\%data) }'`}\" | openssl base64 -A > /tmp/.sdata\n\ncurl -X \"POST\" \"https://api.mixpanel.com/track?data=`cat /tmp/.sdata`\"\n\nrm /tmp/.shw /tmp/.sip /tmp/.sout /tmp/.sdata\n";
 		};
 		CE650540C13A2A8DB9344327 /* [CP] Check Pods Manifest.lock */ = {

--- a/BlockEQ.xcodeproj/xcshareddata/xcschemes/BlockEQ.xcscheme
+++ b/BlockEQ.xcodeproj/xcshareddata/xcschemes/BlockEQ.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/BlockEQ/Views/Asset/AssetHeaderView.swift
+++ b/BlockEQ/Views/Asset/AssetHeaderView.swift
@@ -40,11 +40,9 @@ final class AssetHeaderView: UIView, NibOwnerLoadable {
     }
 
     func update(with viewModel: ViewModel) {
-        assetImageView.image = viewModel.image
         assetNameLabel.text = viewModel.assetTitle
         assetCodeLabel.text = viewModel.assetSubtitle
 
-        assetImageView.image = AssetHeaderView.defaultCurrencyIcon
         assetImageView.isHidden = false
         imageWidthConstraint.constant = 50
 
@@ -55,6 +53,8 @@ final class AssetHeaderView: UIView, NibOwnerLoadable {
             assetImageView.setImage(url: url, placeholder: AssetHeaderView.defaultCurrencyIcon)
         } else if let image = viewModel.image {
             assetImageView.image = image
+        } else if viewModel.image == nil {
+            assetImageView.image = AssetHeaderView.defaultCurrencyIcon
         }
 
         if viewModel.assetSubtitle.isEmpty {

--- a/BlockEQ/Views/Cells/Assets/AssetActionCell.swift
+++ b/BlockEQ/Views/Cells/Assets/AssetActionCell.swift
@@ -38,15 +38,6 @@ final class AssetActionCell: UICollectionViewCell, Reusable, NibOwnerLoadable, I
         setupStyle()
     }
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        headerContainer.update(with: AssetHeaderView.ViewModel.empty)
-        priceContainer.update(with: AssetPriceView.ViewModel.empty)
-        buttonContainer.update(with: AssetButtonView.ViewModel.empty)
-        preferredWidth = nil
-        preferredHeight = nil
-    }
-
     override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/BlockEQ/Views/Cells/Assets/AssetAmountCell.swift
+++ b/BlockEQ/Views/Cells/Assets/AssetAmountCell.swift
@@ -31,14 +31,6 @@ final class AssetAmountCell: UICollectionViewCell, Reusable, NibOwnerLoadable, I
         setupStyle()
     }
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        headerContainer.update(with: AssetHeaderView.ViewModel.empty)
-        priceContainer.update(with: AssetPriceView.ViewModel.empty)
-        preferredWidth = nil
-        preferredHeight = nil
-    }
-
     override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/BlockEQ/Views/Cells/Assets/AssetIssuerCell.swift
+++ b/BlockEQ/Views/Cells/Assets/AssetIssuerCell.swift
@@ -32,15 +32,6 @@ final class AssetIssuerCell: UICollectionViewCell, Reusable, NibOwnerLoadable, I
         setupStyle()
     }
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        headerContainer.update(with: AssetHeaderView.ViewModel.empty)
-        issuerContainer.update(with: AssetIssuerView.ViewModel.empty)
-        priceContainer.update(with: AssetPriceView.ViewModel.empty)
-        preferredWidth = nil
-        preferredHeight = nil
-    }
-
     override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/BlockEQ/Views/Cells/Assets/AssetManageCell.swift
+++ b/BlockEQ/Views/Cells/Assets/AssetManageCell.swift
@@ -43,13 +43,6 @@ final class AssetManageCell: UICollectionViewCell, Reusable, NibOwnerLoadable, I
         setupStyle()
     }
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        headerContainer.update(with: AssetHeaderView.ViewModel.empty)
-        preferredWidth = nil
-        preferredHeight = nil
-    }
-
     override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,7 @@ def shared_pods
   pod 'Alamofire', '~> 4.7'
   pod 'Repeat', '~> 0.5'
   pod 'Reusable', '~> 4.0'
+  pod 'Cache', '~> 5.2'
 end
 
 target 'BlockEQ' do
@@ -18,8 +19,7 @@ target 'BlockEQ' do
   shared_pods
   pod 'SCLAlertView', :git => 'https://github.com/vikmeup/SCLAlertView-Swift', :branch => 'master'
   pod 'Whisper', :git => 'https://github.com/freeubi/Whisper.git', :branch => 'swift-4.2-support'
-  pod 'Cache', '~> 5.2'
-  pod 'Imaginary', '~> 4.2'
+  pod 'Imaginary', :git => 'https://github.com/hyperoslo/Imaginary.git', :branch => 'master'
 
   target 'BlockEQTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -18,7 +18,7 @@ PODS:
 DEPENDENCIES:
   - Alamofire (~> 4.7)
   - Cache (~> 5.2)
-  - Imaginary (~> 4.2)
+  - Imaginary (from `https://github.com/hyperoslo/Imaginary.git`, branch `master`)
   - KeychainSwift (~> 10.0)
   - Repeat (~> 0.5)
   - Reusable (~> 4.0)
@@ -31,13 +31,15 @@ SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - Alamofire
     - Cache
-    - Imaginary
     - KeychainSwift
     - Repeat
     - Reusable
     - SnapshotTesting
 
 EXTERNAL SOURCES:
+  Imaginary:
+    :branch: master
+    :git: https://github.com/hyperoslo/Imaginary.git
   SCLAlertView:
     :branch: master
     :git: https://github.com/vikmeup/SCLAlertView-Swift
@@ -48,6 +50,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/freeubi/Whisper.git
 
 CHECKOUT OPTIONS:
+  Imaginary:
+    :commit: a56a54daafe2b3ab6d8e57df12068d96b77b3cba
+    :git: https://github.com/hyperoslo/Imaginary.git
   SCLAlertView:
     :commit: 86ea7613c99cd4896765fabfa773b39b40bc8590
     :git: https://github.com/vikmeup/SCLAlertView-Swift
@@ -70,6 +75,6 @@ SPEC CHECKSUMS:
   stellar-ios-mac-sdk: 7a49cbb604d6ec8e0e3fefddf34d0d9340db2f1c
   Whisper: 8c499b08f3b56d5c80162d775e3462318ad7f4fe
 
-PODFILE CHECKSUM: ecb842f4ce1d9a47777e7f42c4c162edde6a6c69
+PODFILE CHECKSUM: c16c3a1f64d010dfff91b5763b95469e7be09cbd
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.0.beta.2

--- a/StellarHub.xcodeproj/project.pbxproj
+++ b/StellarHub.xcodeproj/project.pbxproj
@@ -733,8 +733,9 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-StellarHub-StellarHubTests/Pods-StellarHub-StellarHubTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-StellarHub-StellarHubTests/Pods-StellarHub-StellarHubTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/Cache/Cache.framework",
 				"${BUILT_PRODUCTS_DIR}/KeychainSwift/KeychainSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/Repeat/Repeat.framework",
 				"${BUILT_PRODUCTS_DIR}/Reusable/Reusable.framework",
@@ -745,6 +746,7 @@
 			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Cache.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KeychainSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Repeat.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reusable.framework",
@@ -752,7 +754,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-StellarHub-StellarHubTests/Pods-StellarHub-StellarHubTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-StellarHub-StellarHubTests/Pods-StellarHub-StellarHubTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B7DA74BFB191E5D25ACCCF2E /* [CP] Check Pods Manifest.lock */ = {

--- a/StellarHub.xcodeproj/xcshareddata/xcschemes/StellarHub.xcscheme
+++ b/StellarHub.xcodeproj/xcshareddata/xcschemes/StellarHub.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
## Priority
Normal

## Description
This PR corrects behaviour where the [Imaginary](https://github.com/hyperoslo/Imaginary) dependency would set the placeholder image on the `UIImageView` before checking to see if there was already a cached copy.

## Screenshot
![bug](https://user-images.githubusercontent.com/728690/51265524-fc41e600-1986-11e9-9974-ead776e7878a.gif)

## Notes
Upstream issue: https://github.com/hyperoslo/Imaginary/issues/88
Upstream PR: https://github.com/hyperoslo/Imaginary/pull/89