### PR TITLE
[FIX] Missing cell when viewing offers when none posted

### DIFF
--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -111,7 +111,6 @@
 "YOUR_TOKEN_ADDRESS" = "Your Token Address";
 "YOUR_WALLET_ADDRESS" = "Your Wallet Address";
 "ADD_CONTACT" = "Add Contact";
-"UPDATE_CONTACT" = "Update Contact";
 "STELLAR" = "Stellar";
 "SELECT_ASSET" = "Select Asset";
 "NAVIGATE_BACK" = "Back";
@@ -303,3 +302,4 @@
 "TITLE_TITLE" = "Title";
 "AMOUNT_TITLE" = "Amount";
 "VALUE_TITLE" = "Value";
+"EMPTY_OFFERS" = "There are no open offers at the moment.";

--- a/BlockEQ/Views/Cells/OrderBookEmptyCell.swift
+++ b/BlockEQ/Views/Cells/OrderBookEmptyCell.swift
@@ -8,7 +8,7 @@
 
 import Reusable
 
-class OrderBookEmptyCell: UITableViewCell, Reusable {
+class OrderBookEmptyCell: UITableViewCell, Reusable, NibLoadable {
     @IBOutlet weak var label: UILabel!
 
     static let rowHeight: CGFloat = 100.0
@@ -17,5 +17,6 @@ class OrderBookEmptyCell: UITableViewCell, Reusable {
         super.awakeFromNib()
 
         label.textColor = Colors.darkGrayTransparent
+        label.text = "EMPTY_OFFERS".localized()
     }
 }


### PR DESCRIPTION
## Priority
Low

## Description
This PR properly allows the empty cell to load when there are no posted offers. Also updates the text to be localized.

## Screenshot
<img width="545" alt="screen shot 2019-01-16 at 12 37 44 pm" src="https://user-images.githubusercontent.com/728690/51267419-b2a7ca00-198b-11e9-8d1a-2ac50448e6d8.png">
