### PR TITLE
[FIX] Restart streams for account upon new account funding

### DIFF
--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Extensions.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Extensions.swift
@@ -68,6 +68,10 @@ extension ApplicationCoordinator: AccountManagementServiceDelegate {
 
 // MARK: - AccountUpdateServiceDelegate
 extension ApplicationCoordinator: AccountUpdateServiceDelegate {
+    func firstAccountUpdate(_ service: AccountUpdateService, account: StellarAccount) {
+        core?.streamService.subscribeAll(account: account)
+    }
+
     func accountUpdated(_ service: AccountUpdateService,
                         account: StellarAccount,
                         options: AccountUpdateService.UpdateOptions) {

--- a/StellarHub/Protocols.swift
+++ b/StellarHub/Protocols.swift
@@ -29,6 +29,7 @@ protocol AccountUpdateServiceProtocol: AnyObject, Subservice {
 }
 
 public protocol AccountUpdateServiceDelegate: AnyObject {
+    func firstAccountUpdate(_ service: AccountUpdateService, account: StellarAccount)
     func accountUpdated(_ service: AccountUpdateService,
                         account: StellarAccount,
                         options: AccountUpdateService.UpdateOptions)

--- a/StellarHub/Services/StellarIndexingService.swift
+++ b/StellarHub/Services/StellarIndexingService.swift
@@ -199,6 +199,9 @@ extension StellarDataGraph {
 }
 
 extension IndexingService: AccountUpdateServiceDelegate {
+    public func firstAccountUpdate(_ service: AccountUpdateService, account: StellarAccount) {
+    }
+
     public func accountUpdated(_ service: AccountUpdateService,
                                account: StellarAccount,
                                options: AccountUpdateService.UpdateOptions) {

--- a/StellarHubTests/Services/AccountUpdateServiceTests.swift
+++ b/StellarHubTests/Services/AccountUpdateServiceTests.swift
@@ -15,6 +15,9 @@ final class TestAccountUpdateServiceDelegate: AccountUpdateServiceDelegate {
     var callbackOptions: AccountUpdateService.UpdateOptions?
     let asyncUpdateExpectation = XCTestExpectation(description: "Update is called")
 
+    func firstAccountUpdate(_ service: AccountUpdateService, account: StellarAccount) {
+    }
+
     func accountUpdated(_ service: AccountUpdateService,
                         account: StellarAccount,
                         options: AccountUpdateService.UpdateOptions) {


### PR DESCRIPTION
## Priority
Normal

## Description
This PR updates the streaming service to restart for an account when it is funded for the first time. It also decreases the amount of time between manual fetches for account data.