### PR TITLE
[FEATURE] Display QR code in new account state

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		C590B9BE21A0984400B5262A /* ApplicationCoordinator+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = C590B9BD21A0984400B5262A /* ApplicationCoordinator+Debug.swift */; };
 		C590B9C021A098B600B5262A /* ApplicationCoordinator+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C590B9BF21A098B600B5262A /* ApplicationCoordinator+Settings.swift */; };
 		C590B9C221A09A6000B5262A /* ApplicationCoordinator+Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C590B9C121A09A6000B5262A /* ApplicationCoordinator+Wallet.swift */; };
+		C592CC6121F28B630062CE97 /* CacheAccountQROperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C592CC6021F28B630062CE97 /* CacheAccountQROperation.swift */; };
 		C593C46E2092E51A00D6047F /* NavigationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C593C46D2092E51A00D6047F /* NavigationCell.swift */; };
 		C595115620BB2B1B00843D33 /* PinDotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C595115520BB2B1B00843D33 /* PinDotView.swift */; };
 		C599F3D621BEE8B400749AF8 /* StellarHub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C599F3D521BEE8B400749AF8 /* StellarHub.framework */; };
@@ -387,6 +388,7 @@
 		C590B9BD21A0984400B5262A /* ApplicationCoordinator+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApplicationCoordinator+Debug.swift"; sourceTree = "<group>"; };
 		C590B9BF21A098B600B5262A /* ApplicationCoordinator+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApplicationCoordinator+Settings.swift"; sourceTree = "<group>"; };
 		C590B9C121A09A6000B5262A /* ApplicationCoordinator+Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApplicationCoordinator+Wallet.swift"; sourceTree = "<group>"; };
+		C592CC6021F28B630062CE97 /* CacheAccountQROperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheAccountQROperation.swift; sourceTree = "<group>"; };
 		C593C46D2092E51A00D6047F /* NavigationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCell.swift; sourceTree = "<group>"; };
 		C595115520BB2B1B00843D33 /* PinDotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinDotView.swift; sourceTree = "<group>"; };
 		C599F3D521BEE8B400749AF8 /* StellarHub.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StellarHub.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1120,6 +1122,7 @@
 				C514420F217ED86F006C44F4 /* FetchExchangesOperation.swift */,
 				C53E62852199DC94006BF2F1 /* SendDiagnosticOperation.swift */,
 				C54BB76E21EEE89C004396DE /* FetchAssetIconsOperation.swift */,
+				C592CC6021F28B630062CE97 /* CacheAccountQROperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -1643,6 +1646,7 @@
 				C5681BBB21A8B9BD00ACEB21 /* UIViewController+AdvancedSecurity.swift in Sources */,
 				C58D374921B06A23009B44C0 /* PillViewCell.swift in Sources */,
 				ECD3A352207D2CE5000609A0 /* WalletItemActivateCell.swift in Sources */,
+				C592CC6121F28B630062CE97 /* CacheAccountQROperation.swift in Sources */,
 				C53E62862199DC94006BF2F1 /* SendDiagnosticOperation.swift in Sources */,
 				C5114DB7219548AC00C88E4F /* TransactionDetailsDataSource.swift in Sources */,
 				C51B6E5C21B9B553001DFEF7 /* UIViewController+Blurrable.swift in Sources */,

--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
@@ -187,6 +187,7 @@ extension ApplicationCoordinator: SettingsDelegate {
 
             KeychainHelper.clearAll()
             SecurityOptionHelper.clear()
+            CacheManager.shared.clearAccountCache()
 
             self.delegate?.switchToOnboarding()
             self.core?.accountService.clear()

--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Wallet.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Wallet.swift
@@ -41,7 +41,7 @@ extension ApplicationCoordinator: WalletViewControllerDelegate {
         guard let account = core?.accountService.account else { return }
 
         let address = account.accountId
-        let receiveVC = ReceiveViewController(address: address, isPersonalToken: false)
+        let receiveVC = ReceiveViewController(address: address)
         let container = AppNavigationController(rootViewController: receiveVC)
         container.navigationBar.prefersLargeTitles = true
 

--- a/BlockEQ/Coordinators/OnboardingCoordinator.swift
+++ b/BlockEQ/Coordinators/OnboardingCoordinator.swift
@@ -73,6 +73,10 @@ extension OnboardingCoordinator: MnemonicViewControllerDelegate {
                                   passphrase: StellarMnemonicPassphrase?) {
         do {
             try core.accountService.initializeAccount(with: mnemonic, passphrase: passphrase)
+
+            if let account = core.accountService?.account {
+                CacheManager.cacheAccountQRCode(account)
+            }
         } catch {
             core.accountService.clear()
             UIAlertController.simpleAlert(title: "ERROR_TITLE".localized(),
@@ -146,6 +150,11 @@ extension OnboardingCoordinator {
     func save(mnemonic: StellarRecoveryMnemonic, recovered: Bool, passphrase: StellarMnemonicPassphrase?) {
         do {
             try core.accountService.initializeAccount(with: mnemonic, passphrase: passphrase)
+
+            if let account = core.accountService?.account {
+                CacheManager.cacheAccountQRCode(account)
+            }
+
             recordWalletDiagnostic(mnemonic: mnemonic, recovered: recovered, passphrase: passphrase != nil)
         } catch {
             // error
@@ -156,9 +165,14 @@ extension OnboardingCoordinator {
         do {
             try core.accountService.initializeAccount(with: secret)
 
-            guard let accountId = core.accountService.account?.accountId else { return }
+            guard let account = core.accountService.account else { return }
 
-            let diagnostic = WalletDiagnostic(address: accountId, creationMethod: .recoveredSeed, usesPassphrase: false)
+            CacheManager.cacheAccountQRCode(account)
+
+            let diagnostic = WalletDiagnostic(address: account.accountId,
+                                              creationMethod: .recoveredSeed,
+                                              usesPassphrase: false)
+
             KeychainHelper.setDiagnostic(diagnostic)
         } catch {
             // error

--- a/BlockEQ/Operations/CacheAccountQROperation.swift
+++ b/BlockEQ/Operations/CacheAccountQROperation.swift
@@ -1,0 +1,32 @@
+//
+//  CacheAccountQROperation.swift
+//  BlockEQ
+//
+//  Created by Nick DiZazzo on 2019-01-18.
+//  Copyright © 2019 BlockEQ. All rights reserved.
+//
+
+import StellarHub
+import Cache
+
+final class CacheAccountQROperation: Operation {
+    let addressString: String
+    let imageScale = CGFloat(10)
+
+    init(accountId: String) {
+        addressString = accountId
+    }
+
+    override func main() {
+        let qrMap = QRMap(with: addressString, correctionLevel: .full)
+        guard let image = qrMap.scaledTemplateImage(scale: imageScale) else { return }
+
+        let storage = CacheManager.shared.qrCodes
+        do {
+            try storage.setObject(image, forKey: addressString)
+            print("Caching image for \(addressString)")
+        } catch let error {
+            print(error)
+        }
+    }
+}

--- a/BlockEQ/Utils/CacheManager.swift
+++ b/BlockEQ/Utils/CacheManager.swift
@@ -8,11 +8,45 @@
 
 import Cache
 import Imaginary
+import StellarHub
 
 final class CacheManager {
     static let shared = CacheManager()
 
     let images = Configuration.imageStorage
+    var qrCodes: Storage<Image> = {
+        let diskConfig = DiskConfig(name: "QRCodes")
+        let memoryConfig = MemoryConfig(expiry: .never)
 
-    private init() {}
+        do {
+            return try Storage<Image>(diskConfig: diskConfig,
+                                      memoryConfig: memoryConfig,
+                                      transformer: TransformerFactory.forImage())
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+    }()
+
+    private init() { }
+
+    static func cacheAccountQRCode(_ account: StellarAccount) {
+        let queue = OperationQueue()
+        queue.qualityOfService = .userInitiated
+
+        let qrCodeOperation = CacheAccountQROperation(accountId: account.accountId)
+        queue.addOperation(qrCodeOperation)
+    }
+
+    func clearAll() {
+        clearShared()
+        clearAccountCache()
+    }
+
+    func clearShared() {
+        try? images.removeAll()
+    }
+
+    func clearAccountCache() {
+        try? qrCodes.removeAll()
+    }
 }

--- a/BlockEQ/Utils/QRMap.swift
+++ b/BlockEQ/Utils/QRMap.swift
@@ -23,7 +23,10 @@ final class QRMap {
 
     func scaledTemplateImage(scale: CGFloat) -> UIImage? {
         guard let ciImage = self.scaledImage(scaleX: scale, scaleY: scale) else { return nil }
-        let image = UIImage(ciImage: ciImage, scale: UIScreen.main.scale, orientation: .up)
+
+        let context = CIContext.init(options: nil)
+        let image = UIImage(cgImage: context.createCGImage(ciImage, from: ciImage.extent)!)
+
         return image.withRenderingMode(.alwaysTemplate)
     }
 

--- a/BlockEQ/View Controllers/Wallet/WalletViewController.xib
+++ b/BlockEQ/View Controllers/Wallet/WalletViewController.xib
@@ -22,9 +22,9 @@
                 <outlet property="emptyView" destination="vYT-Yd-cac" id="JER-rO-97v"/>
                 <outlet property="emptyViewTitleLabel" destination="usa-Ff-oFo" id="TgW-rh-yDQ"/>
                 <outlet property="headerBackgroundView" destination="waF-WU-V1I" id="qwi-KJ-Pq1"/>
-                <outlet property="inactiveDescriptionLabel" destination="WAS-Qw-Q3D" id="VQh-pD-vjf"/>
-                <outlet property="inactiveImageView" destination="ggN-Ez-aO5" id="0GY-K1-caq"/>
-                <outlet property="inactiveStateView" destination="89I-9N-Fzf" id="1fo-Lb-Alw"/>
+                <outlet property="inactiveDescriptionLabel" destination="WAS-Qw-Q3D" id="Q4t-qZ-sQg"/>
+                <outlet property="inactiveImageView" destination="ggN-Ez-aO5" id="yaO-LD-YqR"/>
+                <outlet property="inactiveStateView" destination="89I-9N-Fzf" id="lxs-Gp-bFL"/>
                 <outlet property="logoImageView" destination="PSG-hA-d0V" id="lIG-qn-FiV"/>
                 <outlet property="tableView" destination="RND-qr-8sK" id="KCK-vC-wWn"/>
                 <outlet property="tableViewHeader" destination="4NM-Ce-BUW" id="OYB-C5-0dx"/>
@@ -126,44 +126,13 @@
                         </constraints>
                     </view>
                 </tableView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="89I-9N-Fzf" userLabel="Inactive State View">
-                    <rect key="frame" x="0.0" y="174" width="375" height="493"/>
-                    <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="wallet-large" translatesAutoresizingMaskIntoConstraints="NO" id="ggN-Ez-aO5">
-                            <rect key="frame" x="125.5" y="184.5" width="124" height="124"/>
-                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstAttribute="width" secondItem="ggN-Ez-aO5" secondAttribute="height" multiplier="1:1" id="6Z3-VN-ViD"/>
-                            </constraints>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="New Wallet Description" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WAS-Qw-Q3D">
-                            <rect key="frame" x="20" y="323.5" width="335" height="17"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstItem="WAS-Qw-Q3D" firstAttribute="top" secondItem="ggN-Ez-aO5" secondAttribute="bottom" constant="15" id="7Ed-Tj-56f"/>
-                        <constraint firstItem="WAS-Qw-Q3D" firstAttribute="leading" secondItem="89I-9N-Fzf" secondAttribute="leading" constant="20" id="Evs-km-BeB"/>
-                        <constraint firstItem="ggN-Ez-aO5" firstAttribute="centerX" secondItem="89I-9N-Fzf" secondAttribute="centerX" id="Kif-9u-5Xi"/>
-                        <constraint firstItem="ggN-Ez-aO5" firstAttribute="centerY" secondItem="89I-9N-Fzf" secondAttribute="centerY" id="ZbD-ML-MTN"/>
-                        <constraint firstItem="ggN-Ez-aO5" firstAttribute="width" secondItem="89I-9N-Fzf" secondAttribute="width" multiplier="0.33" id="dbp-9U-yiV"/>
-                        <constraint firstAttribute="trailing" secondItem="WAS-Qw-Q3D" secondAttribute="trailing" constant="20" id="hsH-xU-rJt"/>
-                    </constraints>
-                </view>
             </subviews>
             <color key="backgroundColor" red="0.96862745098039216" green="0.96862745098039216" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="RND-qr-8sK" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="2Ei-U5-020"/>
-                <constraint firstItem="89I-9N-Fzf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="7Iv-gx-DJ6"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="RND-qr-8sK" secondAttribute="bottom" id="DdX-PD-8FN"/>
                 <constraint firstItem="RND-qr-8sK" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="Jai-af-t3o"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="89I-9N-Fzf" secondAttribute="trailing" id="Jcf-S5-61H"/>
                 <constraint firstItem="RND-qr-8sK" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="UHY-bw-I7y"/>
-                <constraint firstItem="89I-9N-Fzf" firstAttribute="centerY" secondItem="RND-qr-8sK" secondAttribute="centerY" constant="77" id="dh6-hY-l3I"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="89I-9N-Fzf" secondAttribute="bottom" id="tCa-7c-iNH"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="-94.5" y="47.5"/>
@@ -290,6 +259,49 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="DWu-Gg-PDD"/>
             <point key="canvasLocation" x="33.5" y="786"/>
+        </view>
+        <view contentMode="scaleToFill" id="89I-9N-Fzf" userLabel="Inactive State View">
+            <rect key="frame" x="0.0" y="0.0" width="282" height="323"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UK7-Hq-OKk">
+                    <rect key="frame" x="61" y="113.5" width="160" height="192"/>
+                    <subviews>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="wallet-large" translatesAutoresizingMaskIntoConstraints="NO" id="ggN-Ez-aO5">
+                            <rect key="frame" x="0.0" y="0.0" width="160" height="160"/>
+                            <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="ggN-Ez-aO5" secondAttribute="height" multiplier="1:1" id="6Z3-VN-ViD"/>
+                                <constraint firstAttribute="width" constant="160" id="HKI-KX-jW8"/>
+                            </constraints>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="New Wallet Description" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WAS-Qw-Q3D">
+                            <rect key="frame" x="-41" y="175" width="242" height="17"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="WAS-Qw-Q3D" firstAttribute="top" secondItem="ggN-Ez-aO5" secondAttribute="bottom" constant="15" id="C7P-1X-4rP"/>
+                        <constraint firstItem="ggN-Ez-aO5" firstAttribute="width" secondItem="UK7-Hq-OKk" secondAttribute="width" id="CFK-iD-kkf"/>
+                        <constraint firstItem="ggN-Ez-aO5" firstAttribute="centerY" secondItem="UK7-Hq-OKk" secondAttribute="centerY" constant="-16" id="gOI-by-fdx"/>
+                        <constraint firstItem="ggN-Ez-aO5" firstAttribute="centerX" secondItem="UK7-Hq-OKk" secondAttribute="centerX" id="id7-o0-P6F"/>
+                        <constraint firstItem="ggN-Ez-aO5" firstAttribute="top" secondItem="UK7-Hq-OKk" secondAttribute="top" id="sqf-Kt-s6v"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="UK7-Hq-OKk" firstAttribute="centerX" secondItem="2fW-C4-msL" secondAttribute="centerX" id="DXF-vo-CW2"/>
+                <constraint firstItem="WAS-Qw-Q3D" firstAttribute="leading" secondItem="2fW-C4-msL" secondAttribute="leading" constant="20" id="bNQ-Fs-HxW"/>
+                <constraint firstItem="UK7-Hq-OKk" firstAttribute="centerY" secondItem="2fW-C4-msL" secondAttribute="centerY" constant="48" id="rvb-tY-e07"/>
+                <constraint firstItem="2fW-C4-msL" firstAttribute="trailing" secondItem="WAS-Qw-Q3D" secondAttribute="trailing" constant="20" id="s1N-ee-BD0"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="2fW-C4-msL"/>
+            <point key="canvasLocation" x="-688" y="716.49175412293857"/>
         </view>
     </objects>
     <resources>

--- a/StellarHub/Services/Account/AccountUpdateService.swift
+++ b/StellarHub/Services/Account/AccountUpdateService.swift
@@ -166,8 +166,7 @@ extension AccountUpdateService {
     internal func startPeriodicTimer() {
         guard self.timer == nil else { return }
 
-        let interval = accountUpdateInterval
-        self.timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true, block: { _ in
+        self.timer = Timer.scheduledTimer(withTimeInterval: accountUpdateInterval, repeats: true, block: { _ in
             self.update()
         })
     }


### PR DESCRIPTION
## Priority
Normal

## Description
After some discussion with @dabitdev about the empty state for the wallet when newly created - he suggested a good UX improvement to display a QR code to fund the wallet without having to hit "receive". This makes so much more sense.

Since we already had a QR code for the account when created, it wasn't much work to swap out the large wallet icon for the QR code.

## Screenshot
<img width="545" alt="screen shot 2019-01-20 at 2 50 35 pm" src="https://user-images.githubusercontent.com/728690/51444214-0afc0600-1cc3-11e9-983c-3046ce84bf6c.png">