### PR TITLE
[FIX] Corrects minimum balance calculation and associated tests

### DIFF
--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -88,7 +88,7 @@
 "NO_BALANCE_ERROR_TITLE" = "Balance Error";
 "ASSET_ERROR_MESSAGE" = "Sorry your asset could not be added at this time. Please try again later.";
 "ASSET_BALANCE_ERROR_MESSAGE" = "Sorry your asset could not be added at this time. You may need to add more Lumens(XLM) to your wallet and try again as each action costs 0.5 XLM.";
-"LOW_BALANCE_ERROR_MESSAGE" = "You must have an total balance of %@ Lumens (XLM) or greater in order to add a new asset.";
+"LOW_BALANCE_ERROR_MESSAGE" = "You must have a total balance of %@ Lumens (XLM) or greater in order to add a new asset.";
 
 "ASSET_REMOVE_ERROR_MESSAGE" = "Sorry your asset could not be removed at this time. Please try again later.";
 "TOKEN_ERROR_MESSAGE" = "Sorry your personal token could not be added at this time. Please try again later.";

--- a/StellarHub/Objects/StellarAccount.swift
+++ b/StellarHub/Objects/StellarAccount.swift
@@ -134,7 +134,7 @@ public final class StellarAccount {
 
     public var minBalance: Decimal {
         let subentryBalance = Decimal(totalBaseAmount + totalSubentries) * baseReserve
-        return subentryBalance + signers
+        return subentryBalance
     }
 
     public var newEntryMinBalance: Decimal {
@@ -170,9 +170,9 @@ public final class StellarAccount {
      - Note: This amount does not consider amounts locked up in trades.
      */
     public var availableNativeBalance: Decimal {
-        let totalBalance = Decimal(string: nativeAsset.balance) ?? Decimal(0.00)
+        let totalBalance = Decimal(string: nativeAsset.balance) ?? Decimal(0)
         let calculatedBalance = totalBalance - minBalance
-        return calculatedBalance >= 0.0 ? calculatedBalance : totalBalance
+        return calculatedBalance >= 0.0 ? calculatedBalance : Decimal(0)
     }
 
     /**

--- a/StellarHubTests/Objects/StellarAccountTests.swift
+++ b/StellarHubTests/Objects/StellarAccountTests.swift
@@ -53,9 +53,15 @@ class StellarAccountTests: XCTestCase {
     }
 
     func testNewEntryMinimumBalanceCalculatesCorrectAmount() {
-        stubAccount.totalSigners = 3
-        stubAccount.totalSubentries = 2
-        XCTAssertEqual(stubAccount.newEntryMinBalance, 4)
+        stubAccount.totalTrustlines = 1
+        stubAccount.totalSubentries = 3
+        stubAccount.outstandingTradeAmounts[thousandLumens] = 100
+        stubAccount.outstandingTradeAmounts[thousandLumens] = 200
+
+        XCTAssertEqual(stubAccount.totalSubentries, 3)
+        XCTAssertEqual(stubAccount.totalOffers, 2)
+        XCTAssertEqual(stubAccount.minBalance, 2.5)
+        XCTAssertEqual(stubAccount.newEntryMinBalance, 3)
     }
 
     func testHasRequiredNativeBalanceForNewEntryReturnsFalseWhenNoBalance() {
@@ -195,8 +201,9 @@ class StellarAccountTests: XCTestCase {
         XCTAssertEqual(account.totalSigners, 1)
         XCTAssertEqual(account.totalOffers, 1)
         XCTAssertEqual(account.totalTrustlines, 2)
+        XCTAssertEqual(account.totalSubentries, 3)
         XCTAssertEqual(account.totalDataEntries, 0)
-        XCTAssertEqual(account.minBalance, 3)
+        XCTAssertEqual(account.minBalance, 2.5)
     }
 
     func testAvailableBalanceCalculation() {
@@ -206,8 +213,9 @@ class StellarAccountTests: XCTestCase {
         XCTAssertEqual(account.totalSigners, 1)
         XCTAssertEqual(account.totalOffers, 1)
         XCTAssertEqual(account.totalTrustlines, 2)
+        XCTAssertEqual(account.totalSubentries, 3)
         XCTAssertEqual(account.totalDataEntries, 0)
-        XCTAssertEqual(balance.description, "1712.8672173")
+        XCTAssertEqual(balance.description, "1713.3672173")
     }
 
     func testOfferCalculation() {
@@ -253,7 +261,14 @@ class StellarAccountTests: XCTestCase {
         XCTAssertEqual(account.totalDataEntries, 0)
         XCTAssertEqual(account.totalTrustlines, 3)
 
-        XCTAssertEqual(account.availableNativeBalance, 995)
+        XCTAssertEqual(account.availableNativeBalance, 995.5)
+    }
+
+    func testAvailableNativeBalanceReturnsZeroIfLessThanMinBalance() {
+        stubAccount.totalSigners = 1
+        stubAccount.totalSubentries = 4
+        stubAccount.assets[0] = StellarAsset(assetType: AssetTypeAsString.NATIVE, assetCode: nil, assetIssuer: nil, balance: "2")
+        XCTAssertEqual(stubAccount.availableNativeBalance, 0)
     }
 
     func testAvailableBalanceForAssetReturnsZeroIfNoAsset() {
@@ -287,7 +302,7 @@ class StellarAccountTests: XCTestCase {
         XCTAssertEqual(account.totalOffers, 2)
         XCTAssertEqual(account.totalTrustlines, 1)
         XCTAssertEqual(account.totalSigners, 1)
-        XCTAssertEqual(account.availableBalance(for: thousandLumens), 97)
+        XCTAssertEqual(account.availableBalance(for: thousandLumens), 97.5)
     }
 
     func testAssetAvailableBalanceReturnsFullAmountIfNoTrades() {


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects a previously incorrect calculation for minimum balance. Like Lumens, the first signer is NOT counted as a subentry on the user's account. Any additional signer thereafter is.

## Screenshot
N/A