### PR TITLE
[FIX] Make authentication coordinator lazy

### DIFF
--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Settings.swift
@@ -205,7 +205,7 @@ extension ApplicationCoordinator: SettingsDelegate {
         temporaryBiometricSetting = SecurityOptionHelper.optionSetting(for: .useBiometrics)
         authCompletion = completion
 
-        authenticationCoordinator?.authenticate()
+        authenticationCoordinator.authenticate()
     }
 
     func displayMnemonic() {

--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
@@ -117,7 +117,7 @@ final class ApplicationCoordinator {
     var authCompletion: EmptyCompletion?
 
     /// The coordinator responsible for authenticating when the user needs to confirm their PIN
-    var authenticationCoordinator: AuthenticationCoordinator? {
+    lazy var authenticationCoordinator: AuthenticationCoordinator = {
         let opts = AuthenticationCoordinator.AuthenticationOptions(cancellable: true,
                                                                    presentVC: true,
                                                                    forcedStyle: nil,
@@ -127,7 +127,7 @@ final class ApplicationCoordinator {
         authCoordinator.delegate = self
 
         return authCoordinator
-    }
+    }()
 
     var temporaryPinSetting: Bool!
     var temporaryBiometricSetting: Bool!


### PR DESCRIPTION
## Priority
High

## Description
This PR corrects a recently-introduced issue where authentication was being dismissed immediately when leaving scope of the local method, since it was being deallocated when the method returned.

## Screenshot
N/A