### PR TITLE
[FIX] Corrects crash when setting / clearing inflation destination

### DIFF
--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -170,6 +170,7 @@
 "SEND_TO_FORMAT" = "To: %@";
 "SENDING_PAYMENT" = "Sending Payment...";
 "SETTING_INFLATION_DESTINATION" = "Setting Inflation Destination...";
+"CLEARING_INFLATION_DESTINATION" = "Clearing Inflation Destination...";
 "INFLATION_SUCCESSFULLY_UPDATED" = "Inflation successfully updated.";
 "INVALID_DESTINATION_TITLE" = "Invalid Destination";
 "INFLATION_DESTINATION_INVALID" = "Unable to update the inflation destination to your own account, or the account it's already set to.";

--- a/BlockEQ/View Controllers/Assets/AssetListViewController.swift
+++ b/BlockEQ/View Controllers/Assets/AssetListViewController.swift
@@ -30,7 +30,6 @@ final class AssetListViewController: UIViewController {
     @IBOutlet weak var emptyAssetDescriptionLabel: UILabel!
 
     weak var delegate: AssetListViewControllerDelegate?
-
     weak var dataSource: AssetListDataSource? {
         didSet {
             collectionView.dataSource = dataSource
@@ -163,25 +162,6 @@ final class AssetListViewController: UIViewController {
         alert.addAction(UIAlertAction(title: "GENERIC_OK_TEXT".localized(), style: .default, handler: nil))
 
         self.present(alert, animated: true, completion: nil)
-    }
-}
-
-// MARK: - ManageAssetDisplayable
-extension AssetListViewController: ManageAssetDisplayable {
-    func displayLoading(for asset: StellarAsset? = nil) {
-        let message = asset != nil ? "REMOVING_ASSET".localized() : "ADDING_ASSET".localized()
-        showHud(message: message)
-    }
-
-    func hideLoading() {
-        hideHud()
-    }
-
-    func displayError(error: FrameworkError) {
-        hideHud()
-
-        // fixme
-        self.displayFrameworkError(error, fallbackData: (title: "", message: ""))
     }
 }
 

--- a/Podfile
+++ b/Podfile
@@ -25,10 +25,6 @@ target 'BlockEQ' do
     inherit! :search_paths
   end
 
-  target 'BlockEQUITests' do
-    inherit! :search_paths
-  end
-
   target 'BlockEQSnapshotTests' do
     inherit! :search_paths
     pod 'SnapshotTesting'

--- a/StellarHub/Operations/Account/UpdateInflationOperation.swift
+++ b/StellarHub/Operations/Account/UpdateInflationOperation.swift
@@ -14,7 +14,7 @@ internal final class UpdateInflationOperation: AsyncOperation, ChainableOperatio
 
     let horizon: StellarSDK
     let api: StellarConfig.HorizonAPI
-    let address: StellarAddress
+    let address: StellarAddress?
     let userKeys: KeyPair
     let completion: ServiceErrorCompletion
 
@@ -24,12 +24,13 @@ internal final class UpdateInflationOperation: AsyncOperation, ChainableOperatio
     var result: Result<SubmitTransactionResponse> = Result.failure(AsyncOperationError.responseUnset)
 
     private var inflationKeyPair: KeyPair? {
-        return try? KeyPair(accountId: self.address.string)
+        guard let addressString = address?.string else { return nil }
+        return try? KeyPair(accountId: addressString)
     }
 
     init(horizon: StellarSDK,
          api: StellarConfig.HorizonAPI,
-         address: StellarAddress,
+         address: StellarAddress?,
          userKeys: KeyPair,
          completion: @escaping ServiceErrorCompletion) {
         self.horizon = horizon
@@ -44,10 +45,12 @@ internal final class UpdateInflationOperation: AsyncOperation, ChainableOperatio
     override func main() {
         super.main()
 
-        guard let inflationKeyPair = self.inflationKeyPair, let accountResponse = self.inData else {
+        guard let accountResponse = self.inData else {
             finish()
             return
         }
+
+        let inflationKeyPair = self.inflationKeyPair
 
         do {
             let setOptionsOperation = try SetOptionsOperation(sourceAccount: self.userKeys,

--- a/StellarHub/Protocols.swift
+++ b/StellarHub/Protocols.swift
@@ -58,6 +58,7 @@ public protocol SendAmountResponseDelegate: AnyObject {
 
 public protocol SetInflationResponseDelegate: AnyObject {
     func setInflation(destination: StellarAddress)
+    func clearInflation()
     func inflationFailed(error: FrameworkError)
 }
 

--- a/StellarHub/Services/Account/AccountManagementService+Operations.swift
+++ b/StellarHub/Services/Account/AccountManagementService+Operations.swift
@@ -13,15 +13,18 @@ extension AccountManagementService {
     typealias SetInflationOperationPair = ChainedOperationPair<FetchAccountDataOperation, UpdateInflationOperation>
 
     public func setInflationDestination(account: StellarAccount,
-                                        address: StellarAddress,
+                                        address: StellarAddress?,
                                         delegate: SetInflationResponseDelegate) {
         let completion: ServiceErrorCompletion = { error in
             DispatchQueue.main.async {
                 if let error = error {
                     delegate.inflationFailed(error: error)
+                } else if let inflationAddress = address {
+                    account.inflationDestination = inflationAddress.string
+                    delegate.setInflation(destination: inflationAddress)
                 } else {
-                    account.inflationDestination = address.string
-                    delegate.setInflation(destination: address)
+                    account.inflationDestination = nil
+                    delegate.clearInflation()
                 }
             }
         }

--- a/StellarHubTests/TestObjects.swift
+++ b/StellarHubTests/TestObjects.swift
@@ -89,11 +89,17 @@ final class MockInflationResponseDelegate: SetInflationResponseDelegate {
     var error: FrameworkError?
 
     var setInflationCompletion: ((StellarAddress) -> Void)?
+    var clearInflationCompletion: (() -> Void)?
     var errorCompletion: (ServiceErrorCompletion)?
 
     func setInflation(destination: StellarAddress) {
         setInflationAddress = destination
         setInflationCompletion?(destination)
+    }
+
+    func clearInflation() {
+        setInflationAddress = nil
+        clearInflationCompletion?()
     }
 
     func inflationFailed(error: FrameworkError) {


### PR DESCRIPTION
## Priority
High

## Description
This PR moves the presentation and dismissal of alerts, view controllers, etc. when updating the inflation destination. 

This avoids accessing view controllers when they've already been deallocated.

## Screenshot
![fixed](https://user-images.githubusercontent.com/728690/51574039-15accb80-1e7a-11e9-9eed-289f86c9b891.gif)
