### PR TITLE
[FEATURE] Adds support to use the wallet with testnet

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -704,6 +704,15 @@
 			path = Protocols;
 			sourceTree = "<group>";
 		};
+		C56185D221F61262007B6E98 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				C53978CA20BF417100587D99 /* SettingsSwitchCell.swift */,
+				C53978CC20BF4EF000587D99 /* SettingsNormalCell.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		C57A853E217814D40048A6B5 /* Transactions */ = {
 			isa = PBXGroup;
 			children = (
@@ -878,6 +887,7 @@
 		EC0B1917205463DC0052802C /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				C56185D221F61262007B6E98 /* Settings */,
 				C538E58321E7C07C00986D71 /* Balance */,
 				C59AA3CF21D15618007E8362 /* Assets */,
 				C53E629E219B5A6E006BF2F1 /* Diagnostics */,
@@ -904,8 +914,6 @@
 				EC52B3D120BC951F006299A1 /* OffersCell.xib */,
 				EC64CF4D20BF05F5007FE199 /* OrderBookEmptyCell.swift */,
 				EC64CF4E20BF05F5007FE199 /* OrderBookEmptyCell.xib */,
-				C53978CA20BF417100587D99 /* SettingsSwitchCell.swift */,
-				C53978CC20BF4EF000587D99 /* SettingsNormalCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";

--- a/BlockEQ/AppDelegate.swift
+++ b/BlockEQ/AppDelegate.swift
@@ -31,10 +31,34 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
+        let bundleURL = Bundle.main.url(forResource: "Root", withExtension: "plist", subdirectory: "Settings.bundle")
+        readSettings(from: bundleURL)
+
         blockEQWallet.becameActive()
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
         blockEQWallet.enterBackground()
+    }
+}
+
+extension AppDelegate {
+    func readSettings(from bundle: URL?) {
+        let userDefaults = UserDefaults.standard
+        if let url = bundle, let settings = NSDictionary(contentsOf: url),
+            let preferences = settings["PreferenceSpecifiers"] as? [NSDictionary] {
+
+            var defaultsToRegister = [String: AnyObject]()
+            for preference in preferences.enumerated() {
+                let item = preference.element
+                guard let key = item["Key"] as? String, let value = item["DefaultValue"] else {
+                    continue
+                }
+
+                defaultsToRegister[key] = value as AnyObject
+            }
+
+            userDefaults.register(defaults: defaultsToRegister)
+        }
     }
 }

--- a/BlockEQ/BlockEQWallet.swift
+++ b/BlockEQ/BlockEQWallet.swift
@@ -12,13 +12,21 @@ import os.log
 
 final class BlockEQWallet {
     let container = WrapperVC()
-    let core = CoreService(with: .production)
     let onboardingCoordinator = OnboardingCoordinator()
     var appCoordinator = ApplicationCoordinator()
+
     var authenticationCoordinator: AuthenticationCoordinator?
     var onboardingContainer: Bool = false
+    var core: CoreService!
+
+    var network: StellarConfig.HorizonAPI {
+        let network = UserDefaults.standard.string(forKey: "setting.network")
+        return StellarConfig.HorizonAPI.from(string: network)
+    }
 
     init() {
+        core = CoreService(with: network)
+
         onboardingCoordinator.delegate = self
         appCoordinator.delegate = self
 
@@ -47,6 +55,10 @@ final class BlockEQWallet {
         }
     }
 
+    func reset() {
+        core = CoreService(with: network)
+    }
+
     func start() {
         if !KeychainHelper.hasExistingInstance {
             onboardingContainer = true
@@ -69,10 +81,6 @@ final class BlockEQWallet {
         }
     }
 
-    func shutdown() {
-
-    }
-
     func authenticate(_ style: AuthenticationCoordinator.AuthenticationStyle? = nil) {
         guard SecurityOptionHelper.check(.pinOnLaunch) else {
             return
@@ -93,6 +101,8 @@ final class BlockEQWallet {
 
 extension BlockEQWallet: ApplicationCoordinatorDelegate {
     func switchToOnboarding() {
+        reset()
+
         onboardingContainer = true
         onboardingCoordinator.navController.popToRootViewController(animated: false)
         container.moveToViewController(onboardingCoordinator.navController,

--- a/BlockEQ/Resources/Base.lproj/Localizable.strings
+++ b/BlockEQ/Resources/Base.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 "SETTINGS_SECTION_ABOUT" = "About";
 "SETTINGS_SECTION_DEBUG" = "Debug";
 "SETTINGS_SECTION_SUPPORT" = "Support";
+"SETTINGS_SECTION_DEVELOPMENT" = "Development";
 
 "SETTINGS_OPTION_SEED_PHRASE" = "View Mnemonic Phrase";
 "SETTINGS_OPTION_CLEAR_WALLET" = "Clear Wallet";
@@ -39,6 +40,10 @@
 "SETTINGS_OPTION_DIAGNOSTICS" = "Send Diagnostic";
 "SETTINGS_OPTION_INDEXING" = "Indexing Service";
 "SETTINGS_OPTION_MIMIC" = "Mimic Account";
+"SETTINGS_OPTION_NETWORK" = "Network";
+"SETTINGS_OPTION_NETWORK_PRODUCTION" = "Production";
+"SETTINGS_OPTION_NETWORK_TESTNET" = "Testnet";
+"SETTINGS_OPTION_NETWORK_CUSTOM" = "Custom";
 
 "BIOMETRIC_AUTH_TITLE" = "Unlock your wallet";
 "AUTHENTICATE_TITLE" = "Authenticate";
@@ -312,3 +317,5 @@
 "EXISTING_ACCOUNT_REFRESHING" = "Refreshing Wallet";
 "EXISTING_ACCOUNT_UPDATING" = "Updating...";
 "EXISTING_ACCOUNT_INACTIVE" = "Fetching account transactions, please wait.";
+"CLEAR_WALLET_MESSAGE" = "Please clear your wallet and restart the application for the network switch to take effect.";
+"RESTART_REQUIRED" = "Restart Required";

--- a/BlockEQ/Resources/Settings.bundle/Root.plist
+++ b/BlockEQ/Resources/Settings.bundle/Root.plist
@@ -8,6 +8,16 @@
 	<array>
 		<dict>
 			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Development Mode</string>
+			<key>Key</key>
+			<string>setting.development-mode</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 			<key>Title</key>
 			<string>ACKNOWLEDGEMENTS</string>

--- a/BlockEQ/Utils/Constants.swift
+++ b/BlockEQ/Utils/Constants.swift
@@ -53,17 +53,6 @@ public struct Alphas {
     static let transparent = CGFloat(0.2)
 }
 
-public struct HorizonServer {
-    static let production = "https://horizon.stellar.org"
-    static let test = "https://horizon-testnet.stellar.org"
-    static let url = HorizonServer.production
-}
-
-public struct Stellar {
-    static let sdk = StellarSDK(withHorizonUrl: HorizonServer.url)
-    static let network = Network.public
-}
-
 enum MenuItem {
     case wallet
     case trading

--- a/BlockEQ/View Controllers/Settings/EQSettings.swift
+++ b/BlockEQ/View Controllers/Settings/EQSettings.swift
@@ -10,13 +10,38 @@ import Foundation
 
 /// The settings that should appear in the settings menu for BlockEQ.
 struct EQSettings {
+    static let settingsBundleDevelopmentKey = "setting.development-mode"
+
     /// This initalizer populates options based on the scheme selected. Debug options are only included in debug builds.
     static var options: [SettingNode] {
+        var mutableOptions = [walletSection, securitySection, supportSection, aboutSection]
+
+        if UserDefaults.standard.bool(forKey: EQSettings.settingsBundleDevelopmentKey) {
+            mutableOptions.append(developmentSection)
+        }
+
         #if DEBUG
-        return [debugSettings, walletSection, securitySection, supportSection, aboutSection]
-        #else
-        return [walletSection, securitySection, supportSection, aboutSection]
+        mutableOptions.append(debugSection)
         #endif
+
+        return mutableOptions
+    }
+
+    static var networkItems: [SettingNode] {
+        return [
+            SettingNode.node(name: "SETTINGS_OPTION_NETWORK_PRODUCTION".localized(),
+                             identifier: "network-production",
+                             enabled: true,
+                             type: .select),
+            SettingNode.node(name: "SETTINGS_OPTION_NETWORK_TESTNET".localized(),
+                             identifier: "network-testnet",
+                             enabled: true,
+                             type: .select),
+            SettingNode.node(name: "SETTINGS_OPTION_NETWORK_CUSTOM".localized(),
+                             identifier: "network-custom",
+                             enabled: false,
+                             type: .select)
+        ]
     }
 
     static var walletItems: [SettingNode] {
@@ -103,6 +128,7 @@ struct EQSettings {
 
     static var debugItems: [SettingNode] {
         return [
+            networkSection,
             SettingNode.node(name: "SETTINGS_OPTION_MIMIC".localized(),
                              identifier: "debug-mimic-account",
                              enabled: true,
@@ -132,6 +158,12 @@ struct EQSettings {
                                    items: pinItems)
     }
 
+    static var networkSection: SettingNode {
+        return SettingNode.section(name: "SETTINGS_OPTION_NETWORK".localized(),
+                                   identifier: "section-network",
+                                   items: networkItems)
+    }
+
     static var securitySection: SettingNode {
         return SettingNode.section(name: "SETTINGS_SECTION_SECURITY".localized(),
                                    identifier: "section-security",
@@ -150,9 +182,15 @@ struct EQSettings {
                                    items: aboutItems)
     }
 
-    static var debugSettings: SettingNode {
+    static var debugSection: SettingNode {
         return SettingNode.section(name: "SETTINGS_SECTION_DEBUG".localized(),
                                    identifier: "section-debug",
                                    items: debugItems)
+    }
+
+    static var developmentSection: SettingNode {
+        return SettingNode.section(name: "SETTINGS_SECTION_DEVELOPMENT".localized(),
+                                   identifier: "section-development",
+                                   items: [networkSection])
     }
 }

--- a/BlockEQ/View Controllers/Settings/SettingNode.swift
+++ b/BlockEQ/View Controllers/Settings/SettingNode.swift
@@ -16,6 +16,7 @@ enum SettingNode {
     enum NodeType {
         case normal
         case toggle
+        case select
     }
 
     case node(name: String, identifier: String, enabled: Bool, type: NodeType)

--- a/BlockEQ/View Controllers/Settings/SettingsViewController.swift
+++ b/BlockEQ/View Controllers/Settings/SettingsViewController.swift
@@ -24,7 +24,7 @@ final class SettingsViewController: UIViewController {
     }
 
     /// The table view containing settings options.
-    @IBOutlet weak var tableView: UITableView?
+    @IBOutlet var tableView: UITableView!
 
     /// The settings to represent and display in this view controller.
     var optionList: [SettingNode]
@@ -62,16 +62,24 @@ final class SettingsViewController: UIViewController {
     }
 
     func setupView() {
-        tableView?.register(headerFooterViewType: UppercasedTableViewHeader.self)
-        tableView?.register(cellType: SettingsNormalCell.self)
-        tableView?.register(cellType: SettingsSwitchCell.self)
-        tableView?.delegate = self
-        tableView?.dataSource = self
+        tableView.register(headerFooterViewType: UppercasedTableViewHeader.self)
+        tableView.register(cellType: SettingsNormalCell.self)
+        tableView.register(cellType: SettingsSwitchCell.self)
+        tableView.delegate = self
+        tableView.dataSource = self
     }
 
     func setupStyle() {
         let closeButton = navigationItem.rightBarButtonItem
         closeButton?.tintColor = .black
+    }
+
+    func clearCellAccessories() {
+        for index in 0...tableView.numberOfRows(inSection: 0) {
+            let indexPath = IndexPath(row: index, section: 0)
+            let cell = tableView.cellForRow(at: indexPath)
+            cell?.accessoryType = .none
+        }
     }
 
     @objc internal func dismissSettings(sender: UIBarButtonItem) {
@@ -91,6 +99,12 @@ extension SettingsViewController: UITableViewDataSource {
 
         if settingNode.enabled && settingNode.type == .normal {
             self.delegate?.selected(setting: settingNode, value: nil)
+        } else if settingNode.enabled && settingNode.type == .select {
+            self.delegate?.selected(setting: settingNode, value: nil)
+
+            clearCellAccessories()
+            let cell = tableView.cellForRow(at: indexPath)
+            cell?.accessoryType = .checkmark
         }
     }
 }
@@ -105,7 +119,7 @@ extension SettingsViewController: UITableViewDelegate {
             settingCell.update(for: setting)
 
             if let cellValue = delegate?.value(for: setting) {
-                settingCell.setValue(cellValue)
+                settingCell.setValue(node: setting, value: cellValue)
             }
         }
 
@@ -152,6 +166,10 @@ extension SettingNode {
                 let switchCell: SettingsSwitchCell = tableView.dequeueReusableCell(for: indexPath)
                 switchCell.delegate = viewController
                 cell = switchCell
+            case .select:
+                let selectCell: SettingsNormalCell = tableView.dequeueReusableCell(for: indexPath)
+//                selectCell.delegate = viewController
+                cell = selectCell
             }
         }
 

--- a/BlockEQ/View Controllers/Wallet/WalletViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/WalletViewController.swift
@@ -56,6 +56,12 @@ final class WalletViewController: UIViewController {
         navigationItem.setHidesBackButton(true, animated: false)
         navigationController?.setNavigationBarHidden(false, animated: true)
 
+        if let network = UserDefaults.standard.string(forKey: "setting.network"), network == "Testnet" {
+            navigationItem.title = network
+        } else {
+            navigationItem.title = "TITLE_TAB_WALLET".localized()
+        }
+
         inactiveStateView.alpha = 1
         toggleInactiveState(dataSource != nil)
 
@@ -79,7 +85,6 @@ final class WalletViewController: UIViewController {
 
         navigationItem.rightBarButtonItem = rightBarButtonItem
         navigationItem.leftBarButtonItem = leftBarButtonItem
-        navigationItem.title = "TITLE_TAB_WALLET".localized()
 
         assetBalanceButton.setTitle("BALANCE_INFORMATION".localized(), for: .normal)
         inactiveDescriptionLabel.text = "NEW_ACCOUNT_DESCRIPTION".localized()

--- a/BlockEQ/Views/Cells/Settings/SettingsNormalCell.swift
+++ b/BlockEQ/Views/Cells/Settings/SettingsNormalCell.swift
@@ -10,7 +10,7 @@ import Reusable
 
 protocol UpdatableCell {
     func update(for node: SettingNode)
-    func setValue(_ value: String)
+    func setValue(node: SettingNode, value: String)
 }
 
 final class SettingsNormalCell: UITableViewCell, Reusable {
@@ -40,7 +40,9 @@ extension SettingsNormalCell: UpdatableCell {
         textLabel?.text = node.name()
     }
 
-    func setValue(_ value: String) {
-        // noop
+    func setValue(node: SettingNode, value: String) {
+        if node.type == .select && value == node.name {
+            accessoryType = .checkmark
+        }
     }
 }

--- a/BlockEQ/Views/Cells/Settings/SettingsSwitchCell.swift
+++ b/BlockEQ/Views/Cells/Settings/SettingsSwitchCell.swift
@@ -58,4 +58,7 @@ extension SettingsSwitchCell: UpdatableCell {
 
         settingNode = node
     }
+
+    func setValue(node: SettingNode, value: String) {
+    }
 }

--- a/StellarHub/StellarConfig.swift
+++ b/StellarHub/StellarConfig.swift
@@ -11,8 +11,7 @@ import stellarsdk
 public final class StellarConfig {
     internal struct HorizonHostURLs {
         static let production = "https://horizon.stellar.org"
-        static let test = "https://horizon-testnet.stellar.org"
-        static let local = "localhost:3030"
+        static let testnet = "https://horizon-testnet.stellar.org"
     }
 
     public enum HorizonURL {
@@ -29,8 +28,8 @@ public final class StellarConfig {
 
     public enum HorizonAPI {
         case production
-        case test
-        case local
+        case testnet
+        case custom(String)
 
         public var url: URL {
             return URL(string: self.urlString)!
@@ -39,16 +38,33 @@ public final class StellarConfig {
         public var urlString: String {
             switch self {
             case .production: return HorizonHostURLs.production
-            case .test: return HorizonHostURLs.test
-            case .local: return HorizonHostURLs.local
+            case .testnet: return HorizonHostURLs.testnet
+            case .custom(let host):
+                guard let customHost = URL(string: host) else {
+                    return HorizonHostURLs.testnet
+                }
+
+                return customHost.absoluteString
             }
         }
 
         public var network: Network {
             switch self {
             case .production: return Network.public
-            case .test: return Network.testnet
-            case .local: return Network.testnet
+            case .testnet: return Network.testnet
+            case .custom: return Network.testnet
+            }
+        }
+
+        public static func from(string: String?) -> HorizonAPI {
+            guard let networkName = string else { return .production }
+
+            if networkName.lowercased().contains("production") {
+                return .production
+            } else if networkName.lowercased().contains("testnet") {
+                return .testnet
+            } else {
+                return .custom(networkName)
             }
         }
     }

--- a/StellarHubTests/Objects/AccountServiceOperationTests.swift
+++ b/StellarHubTests/Objects/AccountServiceOperationTests.swift
@@ -45,7 +45,7 @@ class AccountServiceOperationTests: XCTestCase {
             keyPair = stubKeyPair
         }
 
-        let env = StellarConfig.HorizonAPI.local
+        let env = StellarConfig.HorizonAPI.custom("localhost")
         let sdk = StellarSDK(withHorizonUrl: env.urlString)
         let core = StubCoreService(sdk: sdk, api: env, secretManager: stubSecretManager, keyPair: keyPair)
 

--- a/StellarHubTests/Services/StellarIndexingServiceTests.swift
+++ b/StellarHubTests/Services/StellarIndexingServiceTests.swift
@@ -38,7 +38,7 @@ class IndexingServiceTests: XCTestCase {
                                                   secretSeed: seed,
                                                   mnemonic: mnemonic)
 
-        let env = StellarConfig.HorizonAPI.local
+        let env = StellarConfig.HorizonAPI.custom("localhost")
         let sdk = StellarSDK(withHorizonUrl: env.urlString)
         let core = StubCoreService(sdk: sdk, api: env, secretManager: stubSecretManager, keyPair: stubKeyPair)
 

--- a/StellarHubTests/Utilities/Common.swift
+++ b/StellarHubTests/Utilities/Common.swift
@@ -22,7 +22,7 @@ func stubCoreService() -> CoreServiceProtocol {
                                               secretSeed: seed,
                                               mnemonic: mnemonic)
 
-    let env = StellarConfig.HorizonAPI.local
+    let env = StellarConfig.HorizonAPI.custom("localhost")
     let sdk = StellarSDK(withHorizonUrl: env.urlString)
     let core = StubCoreService(sdk: sdk, api: env, secretManager: stubSecretManager, keyPair: stubKeyPair)
 


### PR DESCRIPTION
## Priority
Normal

## Description
This PR adds preliminary support to switch between networks. It updates the settings cells to allow for multi-select options, and shoehorns in a `UserDefaults` setting for which network to use.

## Screenshot
<img width="545" alt="screen shot 2019-01-22 at 11 21 11 pm" src="https://user-images.githubusercontent.com/728690/51583005-7ea53b00-1e9c-11e9-9f9f-3846f24da844.png">
<img width="545" alt="screen shot 2019-01-22 at 11 21 20 pm" src="https://user-images.githubusercontent.com/728690/51583006-7ea53b00-1e9c-11e9-8070-acc0d5658fda.png">

## Notes
* We don't yet support custom Horizon URLs, some more refactoring is required first
* A full application restart is required because view controllers are injected with our service layer object on instantiation. An eventual refactor will fix this.

This PR address issue #110 from @fnando. 🎉 
