### PR TITLE
[FIX] Authentication challenges not being displayed in some cases

### DIFF
--- a/BlockEQ/Views/Cells/Settings/SettingsSwitchCell.swift
+++ b/BlockEQ/Views/Cells/Settings/SettingsSwitchCell.swift
@@ -38,10 +38,6 @@ final class SettingsSwitchCell: UITableViewCell, Reusable {
         switchControl.addTarget(self, action: #selector(switchChanged), for: .valueChanged)
     }
 
-    func setValue(_ value: String) {
-        switchControl.isOn = Bool(value) ?? false
-    }
-
     @objc func switchChanged(switch: UISwitch) {
         guard let node = settingNode else { return }
         delegate?.toggledSwitch(for: node, enabled: `switch`.isOn)
@@ -60,5 +56,6 @@ extension SettingsSwitchCell: UpdatableCell {
     }
 
     func setValue(node: SettingNode, value: String) {
+        switchControl.isOn = Bool(value) ?? false
     }
 }


### PR DESCRIPTION
## Priority
Normal

## Description
This PR moves the Authentication view controllers to also be lazily instantiated, so that they may be reset and re-used multiple times. This is to correct an issue where the authentication challenge was not being presented in some cases.

## Screenshot
N/A
