### PR TITLE
[FIX] Initial asset pair in orderbook is XLM / XLM

### DIFF
--- a/BlockEQ/Coordinators/TradingCoordinator.swift
+++ b/BlockEQ/Coordinators/TradingCoordinator.swift
@@ -189,15 +189,18 @@ extension TradingCoordinator: AccountUpdatable {
     func updated(account: StellarAccount) {
 
         if assetPair == nil, let account = accountService.account, account.assets.count > 1 {
-            assetPair = StellarAssetPair(buying: account.assets[1], selling: account.assets[0])
+            let pair = StellarAssetPair(buying: account.assets[1], selling: account.assets[0])
+            assetPair = pair
 
             tradeFromDataSource = TradeAssetListDataSource(assets: account.assets,
-                                                           selected: assetPair?.selling,
+                                                           selected: pair.selling,
                                                            excluding: nil)
 
             tradeToDataSource = TradeAssetListDataSource(assets: account.assets,
-                                                         selected: assetPair?.buying,
-                                                         excluding: assetPair?.buying)
+                                                         selected: pair.buying,
+                                                         excluding: pair.buying)
+
+            tradeService.updateOrders(for: pair, delegate: self)
         }
 
         tradeViewController.refreshView(pair: assetPair)


### PR DESCRIPTION
## Priority
Normal

## Description
This PR corrects an issue where the initial asset pair in the order book was XLM / XLM until the first refresh occurred.