### PR TITLE
[FIX] Refactor AssetListDataSource so shared logic can be used by TradeAssetListDataSource

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		C4E9A77520F79F150028651F /* BalanceViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C4E9A77320F79F150028651F /* BalanceViewController.xib */; };
 		C4EC5FF120F3E64300769E31 /* AddAssetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = C4EC5FEF20F3E64300769E31 /* AddAssetViewController.xib */; };
 		C4F4938A211E19EA000B0800 /* String+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F49389211E19EA000B0800 /* String+Base64.swift */; };
+		C50EB18D21F8F7DF006C4167 /* ConcreteAssetListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50EB18C21F8F7DF006C4167 /* ConcreteAssetListDataSource.swift */; };
 		C50F390220C0AE8100DABB14 /* KeyboardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50F390120C0AE8100DABB14 /* KeyboardHelper.swift */; };
 		C5114DB7219548AC00C88E4F /* TransactionDetailsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5114DB6219548AC00C88E4F /* TransactionDetailsDataSource.swift */; };
 		C51441F5217E5802006C44F4 /* StellarEffect+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51441F4217E5802006C44F4 /* StellarEffect+Extensions.swift */; };
@@ -298,6 +299,7 @@
 		C4E9A77320F79F150028651F /* BalanceViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BalanceViewController.xib; sourceTree = "<group>"; };
 		C4EC5FEF20F3E64300769E31 /* AddAssetViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddAssetViewController.xib; sourceTree = "<group>"; };
 		C4F49389211E19EA000B0800 /* String+Base64.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Base64.swift"; sourceTree = "<group>"; };
+		C50EB18C21F8F7DF006C4167 /* ConcreteAssetListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcreteAssetListDataSource.swift; sourceTree = "<group>"; };
 		C50F390120C0AE8100DABB14 /* KeyboardHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHelper.swift; sourceTree = "<group>"; };
 		C5114DB6219548AC00C88E4F /* TransactionDetailsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsDataSource.swift; sourceTree = "<group>"; };
 		C51441F4217E5802006C44F4 /* StellarEffect+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StellarEffect+Extensions.swift"; sourceTree = "<group>"; };
@@ -607,6 +609,7 @@
 				C5ADFFCE2190C8CC004EA646 /* TradeAssetListDataSource.swift */,
 				C5ADC57621D58D7100DDAF1E /* AccountAssetListDataSource.swift */,
 				C5FDC3F421E3B0F200C911F0 /* AssetBalanceDataSource.swift */,
+				C50EB18C21F8F7DF006C4167 /* ConcreteAssetListDataSource.swift */,
 			);
 			path = "Data Sources";
 			sourceTree = "<group>";
@@ -1596,6 +1599,7 @@
 				C414812E21246A1B0057ED74 /* StellarContactCell.swift in Sources */,
 				ECF9F44B208937E400160843 /* InflationViewController.swift in Sources */,
 				C54EFE4C217A2442005FA6D3 /* TransactionSection.swift in Sources */,
+				C50EB18D21F8F7DF006C4167 /* ConcreteAssetListDataSource.swift in Sources */,
 				C5A5A878215E90BD00007787 /* WebViewController.swift in Sources */,
 				C5A4543221DA8C080096467A /* UIView+CardCell.swift in Sources */,
 				C590B9C221A09A6000B5262A /* ApplicationCoordinator+Wallet.swift in Sources */,

--- a/BlockEQ/Coordinators/AssetCoordinator.swift
+++ b/BlockEQ/Coordinators/AssetCoordinator.swift
@@ -25,11 +25,6 @@ protocol AssetSelectionDelegate: AnyObject {
     func selected(_ asset: StellarAsset)
 }
 
-protocol AssetListDataSource: (UICollectionViewDelegate & UICollectionViewDataSource) {
-    var actionDelegate: AssetActionDelegate? { get set }
-    var selectionDelegate: AssetSelectionDelegate? { get set }
-}
-
 final class AssetCoordinator {
     private let accountService: AccountManagementService
     private var account: StellarAccount

--- a/BlockEQ/Coordinators/PaymentCoordinator.swift
+++ b/BlockEQ/Coordinators/PaymentCoordinator.swift
@@ -78,7 +78,10 @@ final class PaymentCoordinator {
     }()
 
     private lazy var assetListDataSource: AssetListDataSource = {
-        let dataSource = TradeAssetListDataSource(assets: account.assets, selected: nil, excluding: nil)
+        let dataSource = TradeAssetListDataSource(assets: account.assets,
+                                                  availableAssets: [],
+                                                  selected: nil,
+                                                  excluding: nil)
         dataSource.selectionDelegate = self
         dataSource.actionDelegate = self
 

--- a/BlockEQ/Coordinators/TradingCoordinator.swift
+++ b/BlockEQ/Coordinators/TradingCoordinator.swift
@@ -124,21 +124,24 @@ extension TradingCoordinator: AssetCoordinatorDelegate {
             return nil
         }
 
-        let defaultDataSource = TradeAssetListDataSource(assets: account.assets, selected: nil, excluding: nil)
+        let defaultDataSource = TradeAssetListDataSource(assets: account.assets,
+                                                         availableAssets: [],
+                                                         selected: nil,
+                                                         excluding: nil)
 
         guard let field = selectedTradeField else {
             return defaultDataSource
         }
 
-        let accountAssets = account.assets
-
         switch field {
         case .fromAsset:
-            return TradeAssetListDataSource(assets: accountAssets,
+            return TradeAssetListDataSource(assets: account.assets,
+                                            availableAssets: account.availableAssets,
                                             selected: assetPair?.selling,
                                             excluding: nil)
         case .toAsset:
-            return TradeAssetListDataSource(assets: accountAssets,
+            return TradeAssetListDataSource(assets: account.assets,
+                                            availableAssets: account.availableAssets,
                                             selected: assetPair?.buying,
                                             excluding: assetPair?.selling)
         }
@@ -193,10 +196,12 @@ extension TradingCoordinator: AccountUpdatable {
             assetPair = pair
 
             tradeFromDataSource = TradeAssetListDataSource(assets: account.assets,
+                                                           availableAssets: account.availableAssets,
                                                            selected: pair.selling,
                                                            excluding: nil)
 
             tradeToDataSource = TradeAssetListDataSource(assets: account.assets,
+                                                         availableAssets: account.availableAssets,
                                                          selected: pair.buying,
                                                          excluding: pair.buying)
 

--- a/BlockEQ/Data Sources/ConcreteAssetListDataSource.swift
+++ b/BlockEQ/Data Sources/ConcreteAssetListDataSource.swift
@@ -1,0 +1,137 @@
+//
+//  ConcreteAssetListDataSource.swift
+//  BlockEQ
+//
+//  Created by Nick DiZazzo on 2019-01-23.
+//  Copyright © 2019 BlockEQ. All rights reserved.
+//
+
+import StellarHub
+
+protocol AssetListDataSource: UICollectionViewDataSource, UICollectionViewDelegate {
+    var actionDelegate: AssetActionDelegate? { get set }
+    var selectionDelegate: AssetSelectionDelegate? { get set }
+
+    func sortedAssetList(with assets: [StellarAsset]) -> [StellarAsset]
+    func asset(for: IndexPath) -> StellarAsset?
+    func selectedAction(mode: AssetManageCell.Mode, cellPath: IndexPath?)
+
+    func manageCell(collectionView: UICollectionView,
+                    for path: IndexPath,
+                    asset: StellarAsset,
+                    mode: AssetManageCell.Mode) -> AssetManageCell
+
+    func amountCell(collectionView: UICollectionView,
+                    for path: IndexPath,
+                    asset: StellarAsset) -> AssetAmountCell
+}
+
+extension AssetListDataSource {
+    func sortedAssetList(with assets: [StellarAsset]) -> [StellarAsset] {
+        var assetsToSort = assets
+        var result: [StellarAsset] = []
+
+        // Always insert Lumens first
+        if assetsToSort.count > 0 {
+            result.append(assetsToSort.removeFirst())
+        }
+
+        // Sort remaining assets by balance
+        result.append(contentsOf:
+            assetsToSort.sorted(by: { (first, second) -> Bool in
+                guard let firstBalance = Decimal(string: first.balance) else { return false }
+                guard let secondBalance = Decimal(string: second.balance)  else { return false }
+                return firstBalance > secondBalance
+            })
+        )
+
+        return result
+    }
+
+    func manageCell(collectionView: UICollectionView,
+                    for path: IndexPath,
+                    asset: StellarAsset,
+                    mode: AssetManageCell.Mode) -> AssetManageCell {
+        let cell: AssetManageCell = collectionView.dequeueReusableCell(for: path)
+
+        let model = AssetManageCell.ViewModel(headerData: asset.headerViewModel, mode: mode)
+        cell.update(with: model, indexPath: path)
+        return cell
+    }
+
+    func amountCell(collectionView: UICollectionView, for path: IndexPath, asset: StellarAsset) -> AssetAmountCell {
+        let cell: AssetAmountCell = collectionView.dequeueReusableCell(for: path)
+
+        let model = AssetAmountCell.ViewModel(headerData: asset.headerViewModel, priceData: asset.priceViewModel)
+        cell.update(with: model, indexPath: path)
+        return cell
+    }
+
+    func selectedAction(mode: AssetManageCell.Mode, cellPath: IndexPath?) {
+        guard let indexPath = cellPath, let asset = self.asset(for: indexPath) else { return }
+
+        switch mode {
+        case .add:
+            actionDelegate?.requestedAdd(asset: asset)
+        case .remove:
+            actionDelegate?.requestedRemove(asset: asset)
+        }
+    }
+}
+
+class ExtendableAssetListDataSource: NSObject, AssetListDataSource {
+    weak var actionDelegate: AssetActionDelegate?
+    weak var selectionDelegate: AssetSelectionDelegate?
+
+    func asset(for: IndexPath) -> StellarAsset? {
+        fatalError("Must be overridden")
+    }
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        fatalError("Must be overridden")
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        fatalError("Must be overridden")
+    }
+
+    func collectionView(_ collectionView: UICollectionView,
+                        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        fatalError("Must be overridden")
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let asset = self.asset(for: indexPath) else {
+            return
+        }
+
+        if let cell = collectionView.cellForItem(at: indexPath) as? StylableAssetCell {
+            cell.select()
+        }
+
+        selectionDelegate?.selected(asset)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        return indexPath.section == 0 ? true : false
+    }
+
+    @objc func collectionView(_ collectionView: UICollectionView,
+                              viewForSupplementaryElementOfKind kind: String,
+                              at indexPath: IndexPath) -> UICollectionReusableView {
+        let header: AssetListHeader = collectionView.dequeueHeader(for: indexPath)
+        header.headerTitleLabel.text = "BLOCKEQ_ASSET_TITLE".localized()
+        return header
+    }
+
+    @objc func collectionView(_ collectionView: UICollectionView,
+                              layout collectionViewLayout: UICollectionViewLayout,
+                              referenceSizeForHeaderInSection section: Int) -> CGSize {
+        guard self.collectionView(collectionView, numberOfItemsInSection: section) > 0 else { return .zero }
+
+        switch section {
+        case 1: return CGSize(width: collectionView.bounds.width, height: 30)
+        default: return .zero
+        }
+    }
+}

--- a/BlockEQ/View Controllers/Keys/SecretSeedViewController.swift
+++ b/BlockEQ/View Controllers/Keys/SecretSeedViewController.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 BlockEQ. All rights reserved.
 //
 
-import Whisper
 import stellarsdk
 import StellarHub
 

--- a/BlockEQ/View Controllers/Wallet/AddAssetViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/AddAssetViewController.swift
@@ -13,7 +13,6 @@ protocol AddAssetViewControllerDelegate: class {
 }
 
 class AddAssetViewController: UIViewController {
-
     @IBOutlet var assetCodeTextField: UITextField!
     @IBOutlet var issuerTextField: UITextField!
     @IBOutlet var holdingView: UIView!
@@ -35,6 +34,8 @@ class AddAssetViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        issuerTextField.text = ""
+        assetCodeTextField.text = ""
         view.endEditing(true)
     }
 


### PR DESCRIPTION
## Priority
Normal

## Description
This PR refactors the `AssetListDataSource` protocol so that shared code can be pulled into a concrete subclass of `NSObject`, and extended for both the `TradeAssetListDatasource` and `AccountAssetListDataSource`

## Screenshot
<img width="545" alt="screen shot 2019-01-23 at 3 09 30 pm" src="https://user-images.githubusercontent.com/728690/51633951-e8ffbf00-1f20-11e9-9293-ecae8a0ee6be.png">