### PR TITLE
[FIX] This corrects some behaviour when adding assets via Trade

### DIFF
--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Wallet.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Wallet.swift
@@ -79,6 +79,12 @@ extension ApplicationCoordinator: WalletViewControllerDelegate {
 }
 
 extension ApplicationCoordinator: AssetCoordinatorDelegate {
+    func added(asset: StellarAsset, account: StellarAccount) {
+    }
+
+    func removed(asset: StellarAsset, account: StellarAccount) {
+    }
+
     func selected(asset: StellarAsset) {
         guard let account = core?.accountService.account else { return }
         walletViewController.update(with: account, asset: asset)

--- a/BlockEQ/Coordinators/AssetCoordinator.swift
+++ b/BlockEQ/Coordinators/AssetCoordinator.swift
@@ -11,6 +11,8 @@ import Whisper
 
 protocol AssetCoordinatorDelegate: AnyObject {
     func selected(asset: StellarAsset)
+    func added(asset: StellarAsset, account: StellarAccount)
+    func removed(asset: StellarAsset, account: StellarAccount)
     func dismissed(coordinator: AssetCoordinator, viewController: UIViewController)
     func dataSource() -> AssetListDataSource?
 }
@@ -214,13 +216,13 @@ extension AssetCoordinator: ManageAssetResponseDelegate {
     func added(asset: StellarAsset, account: StellarAccount) {
         reload()
         hideHud()
-        assetListViewController.reload()
+        delegate?.added(asset: asset, account: account)
     }
 
     func removed(asset: StellarAsset, account: StellarAccount) {
         reload()
         hideHud()
-        assetListViewController.reload()
+        delegate?.removed(asset: asset, account: account)
     }
 
     func manageFailed(error: FrameworkError) {

--- a/BlockEQ/Coordinators/TradingCoordinator.swift
+++ b/BlockEQ/Coordinators/TradingCoordinator.swift
@@ -119,6 +119,13 @@ extension TradingCoordinator: TradeAssetListDisplayable {
 }
 
 extension TradingCoordinator: AssetCoordinatorDelegate {
+    func added(asset: StellarAsset, account: StellarAccount) {
+        updated(account: account)
+    }
+
+    func removed(asset: StellarAsset, account: StellarAccount) {
+    }
+
     func dataSource() -> AssetListDataSource? {
         guard let account = accountService.account else {
             return nil
@@ -144,6 +151,12 @@ extension TradingCoordinator: AssetCoordinatorDelegate {
                                             availableAssets: account.availableAssets,
                                             selected: assetPair?.buying,
                                             excluding: assetPair?.selling)
+        case .firstTimeAdd:
+            let assets = account.assets.count > 1 ? account.assets : account.availableAssets
+            return TradeAssetListDataSource(assets: assets,
+                                            availableAssets: account.availableAssets,
+                                            selected: nil,
+                                            excluding: account.assets.first)
         }
     }
 
@@ -171,6 +184,7 @@ extension TradingCoordinator: AssetCoordinatorDelegate {
         case .toAsset:
             toAsset = asset
             fromAsset = previousFromAsset == asset ? account.firstAssetExcluding(toAsset) : previousFromAsset
+        default: break
         }
 
         if let fromAsset = fromAsset, let toAsset = toAsset {
@@ -220,7 +234,7 @@ extension TradingCoordinator: TradeSegmentControllerDelegate {
     }
 
     func displayAssetList() {
-        self.requestedDisplayAssetList(for: .fromAsset)
+        self.requestedDisplayAssetList(for: .firstTimeAdd)
     }
 }
 

--- a/BlockEQ/Data Sources/TradeAssetListDataSource.swift
+++ b/BlockEQ/Data Sources/TradeAssetListDataSource.swift
@@ -28,7 +28,7 @@ final class TradeAssetListDataSource: ExtendableAssetListDataSource, AssetManage
     }
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 2
+        return assets == availableAssets ? 1 : 2
     }
 
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -37,16 +37,15 @@ final class TradeAssetListDataSource: ExtendableAssetListDataSource, AssetManage
 
     override func collectionView(_ collectionView: UICollectionView,
                                  cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        var cell: UICollectionViewCell
-        guard let asset = self.asset(for: indexPath) else { return UICollectionViewCell() }
+        var cell = UICollectionViewCell()
+        guard let asset = self.asset(for: indexPath) else { return cell }
 
-        if !asset.hasZeroBalance {
-            cell = self.amountCell(collectionView: collectionView, for: indexPath, asset: asset)
-        } else {
-            let mode: AssetManageCell.Mode = availableAssets.contains(asset) ? .add : .remove
-            let manageCell = self.manageCell(collectionView: collectionView, for: indexPath, asset: asset, mode: mode)
+        if availableAssets.contains(asset) {
+            let manageCell = self.manageCell(collectionView: collectionView, for: indexPath, asset: asset, mode: .add)
             manageCell.delegate = self
             cell = manageCell
+        } else {
+            cell = self.amountCell(collectionView: collectionView, for: indexPath, asset: asset)
         }
 
         if var styleCell = cell as? StylableAssetCell {

--- a/BlockEQ/Extensions/UIViewController+AdvancedSecurity.swift
+++ b/BlockEQ/Extensions/UIViewController+AdvancedSecurity.swift
@@ -58,6 +58,7 @@ extension PassphrasePromptable where Self: UIViewController {
 
     func clearPassphrase() {
         passphraseButton.setTitle("ADVANCED_SECURITY_TITLE".localized(), for: .normal)
+        self.temporaryPassphrase = nil
         self.mnemonicPassphrase = nil
     }
 

--- a/BlockEQ/View Controllers/Assets/AssetListViewController.swift
+++ b/BlockEQ/View Controllers/Assets/AssetListViewController.swift
@@ -106,7 +106,15 @@ final class AssetListViewController: UIViewController {
             collectionView.reloadData()
         }
 
-        if let dataSource = dataSource, dataSource.collectionView(collectionView, numberOfItemsInSection: 0) == 0 {
+        guard let dataSource = dataSource else {
+            showEmptyAssets()
+            return
+        }
+
+        let assetItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 0)
+        let availableItems = dataSource.collectionView(collectionView, numberOfItemsInSection: 1)
+
+        if assetItems == 0, availableItems == 0 {
             showEmptyAssets()
         } else {
             hideEmptyAssets()

--- a/BlockEQ/View Controllers/Trade/TradeViewController.swift
+++ b/BlockEQ/View Controllers/Trade/TradeViewController.swift
@@ -47,6 +47,7 @@ extension TradeViewController {
     enum TradeField {
         case fromAsset
         case toAsset
+        case firstTimeAdd
     }
 }
 


### PR DESCRIPTION
## Priority
Normal

## Description
This PR makes it a nicer UX when you are adding an asset for the first time in the Trade screen, by either displaying 1 or two sections, depending on which assets currently have trustlines on the account.

## Screenshot
![fixed](https://user-images.githubusercontent.com/728690/51641538-62ed7380-1f34-11e9-9063-6d9ef419785a.gif)

## Notes
* You can no longer remove assets from the trade screen, doing so doesn't make sense
* Smart selection for when to display available assets as a separate section
