### PR TITLE
[FIX] Displays the low balance error when adding an asset via the green +

### DIFF
--- a/BlockEQ/Coordinators/AssetCoordinator.swift
+++ b/BlockEQ/Coordinators/AssetCoordinator.swift
@@ -91,6 +91,12 @@ final class AssetCoordinator {
     }
 
     func add(_ asset: StellarAsset, to account: StellarAccount) {
+        guard account.hasRequiredNativeBalanceForNewEntry else {
+            let minimumBalance = account.newEntryMinBalance.displayFormattedString
+            assetListViewController.displayLowBalanceError(minimum: minimumBalance)
+            return
+        }
+
         showHud(message: "ADDING_ASSET".localized())
         accountService.changeTrust(account: account, asset: asset, remove: false, delegate: self)
     }


### PR DESCRIPTION
## Priority
Normal

## Description
Adds the error message to the action when the user taps the `+` on an`AssetManageCell`

## Screenshot
![img_02f66791c04a-1](https://user-images.githubusercontent.com/728690/51648641-47439680-1f4f-11e9-87ad-7f4bc64cc607.jpeg)
