### PR TITLE
[FIX] Prevents trade segments from switching when no assets added

### DIFF
--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
@@ -190,8 +190,8 @@ final class ApplicationCoordinator {
 }
 
 extension ApplicationCoordinator: TradeHeaderViewDelegate {
-    func switchedSegment(_ type: TradeSegment) {
-        tradingCoordinator?.switchedSegment(type)
+    func switchedSegment(_ type: TradeSegment) -> Bool {
+        return tradingCoordinator?.switchedSegment(type) ?? false
     }
 }
 

--- a/BlockEQ/Coordinators/TradingCoordinator.swift
+++ b/BlockEQ/Coordinators/TradingCoordinator.swift
@@ -77,8 +77,8 @@ final class TradingCoordinator {
         orderbookViewController.delegate = self
     }
 
-    func switchedSegment(_ type: TradeSegment) {
-        segmentController.switchSegment(type)
+    func switchedSegment(_ type: TradeSegment) -> Bool {
+        return segmentController.switchSegment(type)
     }
 
     func startPeriodicOrderbookUpdates() {

--- a/BlockEQ/View Controllers/Trade/TradeSegmentViewController.swift
+++ b/BlockEQ/View Controllers/Trade/TradeSegmentViewController.swift
@@ -95,9 +95,12 @@ final class TradeSegmentViewController: UIViewController {
         scrollView.showsHorizontalScrollIndicator = false
     }
 
-    func switchSegment(_ type: TradeSegment) {
+    func switchSegment(_ type: TradeSegment) -> Bool {
+        guard displayNoAssetOverlay != true else { return false }
+
         let offset = CGPoint(x: scrollView.frame.size.width * CGFloat(type.rawValue), y: 0.0)
         scrollView.setContentOffset(offset, animated: true)
+        return true
     }
 
     func displayNoAssetOverlayView() {

--- a/BlockEQ/Views/TradeHeaderView.swift
+++ b/BlockEQ/Views/TradeHeaderView.swift
@@ -19,7 +19,7 @@ enum TradeSegment: Int {
 }
 
 protocol TradeHeaderViewDelegate: AnyObject {
-    func switchedSegment(_ type: TradeSegment)
+    func switchedSegment(_ type: TradeSegment) -> Bool
 }
 
 class TradeHeaderView: UIView, NibOwnerLoadable {
@@ -67,8 +67,9 @@ class TradeHeaderView: UIView, NibOwnerLoadable {
     }
 
     func setSelected(selectedButton: UIButton, animated: Bool) {
-        setTitleSelected(index: selectedButton.tag)
-
-        tradeHeaderViewDelegate?.switchedSegment(TradeSegment.all[selectedButton.tag])
+        let segment = TradeSegment.all[selectedButton.tag]
+        if tradeHeaderViewDelegate?.switchedSegment(segment) == true {
+            setTitleSelected(index: selectedButton.tag)
+        }
     }
 }


### PR DESCRIPTION
## Priority
Low

## Description
This PR corrects a small UX bug where you could switch segments when trading when no assets were added.

## Screenshot
![fixed](https://user-images.githubusercontent.com/728690/51650965-32b7cc00-1f58-11e9-8091-49f315d8c45c.gif)