### PR TITLE
[FIX] Correct missing localization key for new account

### DIFF
--- a/BlockEQ/View Controllers/Wallet/WalletViewController.swift
+++ b/BlockEQ/View Controllers/Wallet/WalletViewController.swift
@@ -87,7 +87,7 @@ final class WalletViewController: UIViewController {
         navigationItem.leftBarButtonItem = leftBarButtonItem
 
         assetBalanceButton.setTitle("BALANCE_INFORMATION".localized(), for: .normal)
-        inactiveDescriptionLabel.text = "NEW_ACCOUNT_DESCRIPTION".localized()
+        inactiveDescriptionLabel.text = "EXISTING_ACCOUNT_INACTIVE".localized()
         inactiveDescriptionLabel.textColor = Colors.darkGray
 
         inactiveImageView.image = UIImage(named: "wallet-large")
@@ -103,6 +103,8 @@ final class WalletViewController: UIViewController {
         tableViewHeaderRightLabel.textColor = Colors.darkGrayTransparent
         tableView?.backgroundColor = Colors.lightBackground
         tableView?.separatorStyle = .none
+
+        update(with: state.viewModel)
     }
 
     func toggleInactiveState(_ hidden: Bool, animated: Bool = true) {


### PR DESCRIPTION
## Priority
Low

## Description
When the view controller is first loaded, the default XIB information set in text fields. If the account fails to update, this data is not meant to be left in the initial state, and should be updated to reflect what the app is doing.

## Screenshot
![unnamed](https://user-images.githubusercontent.com/728690/51850729-55e3d200-22f0-11e9-8926-8b3efa0b5250.png)

## Notes
* This issue was reported by one of our users after recovering via iCloud (which does not transfer the user's keychain information to the new device). Some work will have to be done to make that iCloud restore experience less confusing.