### PR TITLE
[FIX] Prevent account from updating an unreasonable number of times when stream updates received

### DIFF
--- a/BlockEQ.xcodeproj/xcshareddata/xcschemes/BlockEQ.xcscheme
+++ b/BlockEQ.xcodeproj/xcshareddata/xcschemes/BlockEQ.xcscheme
@@ -153,7 +153,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"

--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+AccountExtensions.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+AccountExtensions.swift
@@ -43,6 +43,6 @@ extension ApplicationCoordinator: StreamServiceDelegate {
     }
 
     func receivedObjects(stream: StreamService.StreamType) {
-        core.updateService.update()
+        streamUpdateThrottler.call()
     }
 }

--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
@@ -8,6 +8,7 @@
 
 import StellarHub
 import WebKit
+import Repeat
 import os.log
 
 protocol ApplicationCoordinatorDelegate: AnyObject {
@@ -32,6 +33,13 @@ final class ApplicationCoordinator {
 
     // The coordinator responsible for managing application diagnostics
     let diagnosticCoordinator = DiagnosticCoordinator()
+
+    // A safety object to throttle how many requests to update data we make when receiving stream objects
+    lazy var streamUpdateThrottler: Throttler = {
+        return Throttler(time: .seconds(5), { [unowned self] in
+            self.core.updateService.update()
+        })
+    }()
 
     /// The service object that manages interactions with the Stellar network
     var core: CoreService

--- a/StellarHub/Services/Streaming/StreamService.swift
+++ b/StellarHub/Services/Streaming/StreamService.swift
@@ -68,19 +68,19 @@ public final class StreamService: StreamServiceProtocol {
         switch stream {
         case .effects:
             guard effectsStream == nil else { return }
-            let eStream = EffectStreamListener(core: core, account: account)
+            let eStream = EffectStreamListener(core: core, account: account, cursor: "now")
             eStream.delegate = self
             streamObject = eStream
             self.effectsStream = streamObject
         case .operations:
             guard operationsStream == nil else { return }
-            let oStream = OperationStreamListener(core: core, account: account)
+            let oStream = OperationStreamListener(core: core, account: account, cursor: "now")
             oStream.delegate = self
             streamObject = oStream
             operationsStream = streamObject
         case .transactions:
             guard transactionsStream == nil else { return }
-            let tStream = TransactionStreamListener(core: core, account: account)
+            let tStream = TransactionStreamListener(core: core, account: account, cursor: "now")
             tStream.delegate = self
             streamObject = tStream
             transactionsStream = streamObject


### PR DESCRIPTION
## Priority
Urgent

## Description
This PR corrects an unintended number of updates from being requested from the Horizon API when streaming objects are returned from the `StreamingService` and stream objects from the Soneso SDK.

## Screenshot
N/A