### PR TITLE
[FIX] Corrects indexing from being run due to recording the completion too early

### DIFF
--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Debug.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Debug.swift
@@ -13,7 +13,9 @@ extension ApplicationCoordinator: IndexingViewControllerDelegate {
     }
 
     func requestedRestartIndexing(_ viewController: IndexingViewController) {
-        core.indexingService.rebuildIndex()
+        guard let account = core.accountService.account else { return }
+
+        core.indexingService.rebuildIndex(for: account)
         indexingViewController?.update(with: 0, error: nil)
     }
 }

--- a/StellarHub.xcodeproj/project.pbxproj
+++ b/StellarHub.xcodeproj/project.pbxproj
@@ -95,7 +95,7 @@
 		C5F1CA08217A9C61001C847A /* CreatePersonalTokenOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1CA07217A9C61001C847A /* CreatePersonalTokenOperation.swift */; };
 		C5F1CA0A217A9C86001C847A /* FetchPersonalTokenOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1CA09217A9C86001C847A /* FetchPersonalTokenOperation.swift */; };
 		C5F1CA0C217A9F1E001C847A /* SecretManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F1CA0B217A9F1E001C847A /* SecretManager.swift */; };
-		C5FE7578218AAECB0090E372 /* StellarIndexingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FE7577218AAECB0090E372 /* StellarIndexingService.swift */; };
+		C5FE7578218AAECB0090E372 /* IndexingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FE7577218AAECB0090E372 /* IndexingService.swift */; };
 		C5FE757A218BC7EE0090E372 /* StellarAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FE7579218BC7EE0090E372 /* StellarAddressTests.swift */; };
 		C5FE757C218BC87D0090E372 /* TestHelperData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FE757B218BC87D0090E372 /* TestHelperData.swift */; };
 		C5FE757F218BCBE70090E372 /* StellarSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FE757E218BCBE70090E372 /* StellarSeedTests.swift */; };
@@ -222,7 +222,7 @@
 		C5F1CA07217A9C61001C847A /* CreatePersonalTokenOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePersonalTokenOperation.swift; sourceTree = "<group>"; };
 		C5F1CA09217A9C86001C847A /* FetchPersonalTokenOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPersonalTokenOperation.swift; sourceTree = "<group>"; };
 		C5F1CA0B217A9F1E001C847A /* SecretManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretManager.swift; sourceTree = "<group>"; };
-		C5FE7577218AAECB0090E372 /* StellarIndexingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StellarIndexingService.swift; sourceTree = "<group>"; };
+		C5FE7577218AAECB0090E372 /* IndexingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexingService.swift; sourceTree = "<group>"; };
 		C5FE7579218BC7EE0090E372 /* StellarAddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StellarAddressTests.swift; sourceTree = "<group>"; };
 		C5FE757B218BC87D0090E372 /* TestHelperData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelperData.swift; sourceTree = "<group>"; };
 		C5FE757E218BCBE70090E372 /* StellarSeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StellarSeedTests.swift; sourceTree = "<group>"; };
@@ -408,7 +408,7 @@
 				C55F926021C8969D00846B81 /* Streaming */,
 				C5D8CAD2218242A4009F8624 /* TradeService.swift */,
 				C5ECF41E2183BADE004BB240 /* CoreService.swift */,
-				C5FE7577218AAECB0090E372 /* StellarIndexingService.swift */,
+				C5FE7577218AAECB0090E372 /* IndexingService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -842,7 +842,7 @@
 				C512E6A3217FCCB000D1AC74 /* Result.swift in Sources */,
 				C51441EE217D7481006C44F4 /* StellarConfig.swift in Sources */,
 				C558412821AC459C0090D463 /* StellarMnemonicPassphrase.swift in Sources */,
-				C5FE7578218AAECB0090E372 /* StellarIndexingService.swift in Sources */,
+				C5FE7578218AAECB0090E372 /* IndexingService.swift in Sources */,
 				C55F926221C898CB00846B81 /* StreamProcessor.swift in Sources */,
 				C51441E5217AEE17006C44F4 /* FetchOffersOperation.swift in Sources */,
 				C5082EE921C9DC7C00CDDBD6 /* AccountUpdateService.swift in Sources */,

--- a/StellarHub/Protocols.swift
+++ b/StellarHub/Protocols.swift
@@ -87,8 +87,8 @@ public protocol OfferResponseDelegate: AnyObject {
 
 // MARK: - IndexingService
 protocol IndexingServiceProtocol: Subservice {
-    func updateIndex()
-    func rebuildIndex()
+    func updateIndex(for account: StellarAccount)
+    func rebuildIndex(for account: StellarAccount)
     func reset()
     func pause()
     func resume()


### PR DESCRIPTION
## Priority
Normal

## Description
This PR moves recording the last index account hash to when the operation completes. This allows indexing to run after operations, transactions and effects are fetched.

## Screenshot
N/A