### PR TITLE
[FIX] Correct top area constraint on AppTabController

### DIFF
--- a/BlockEQ/View Controllers/Application/AppTabController.xib
+++ b/BlockEQ/View Controllers/Application/AppTabController.xib
@@ -23,7 +23,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eIF-c7-SkW" userLabel="Main Container View">
-                    <rect key="frame" x="0.0" y="44" width="375" height="684"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="728"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EtZ-I7-bY1" userLabel="Tab Container View">
@@ -49,7 +49,7 @@
             <color key="backgroundColor" red="0.97254901960784312" green="0.97254901960784312" blue="0.97254901960784312" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="zKi-fb-T6g" firstAttribute="trailing" secondItem="eIF-c7-SkW" secondAttribute="trailing" id="0R2-2N-6gg"/>
-                <constraint firstItem="eIF-c7-SkW" firstAttribute="top" secondItem="zKi-fb-T6g" secondAttribute="top" id="CCe-tJ-92l"/>
+                <constraint firstItem="eIF-c7-SkW" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="CCe-tJ-92l"/>
                 <constraint firstAttribute="bottomMargin" secondItem="EtZ-I7-bY1" secondAttribute="bottom" id="EN2-G7-vbb"/>
                 <constraint firstItem="zKi-fb-T6g" firstAttribute="bottom" secondItem="1gV-em-Jgf" secondAttribute="bottom" id="KKx-BE-IGr"/>
                 <constraint firstItem="EtZ-I7-bY1" firstAttribute="leading" secondItem="zKi-fb-T6g" secondAttribute="leading" id="U5e-WA-W2h"/>


### PR DESCRIPTION
## Priority
Normal

## Description
This PR corrects the top constraint in the AppTabController to be pinned to the superview instead of the safe area. This allows sub view controllers to take the full height of the screen (including the nav bar).

Child VCs can still avoid the navigation bar or the top area on notched devices by respecting the safe area layout margin.

## Screenshot
N/A