### PR TITLE
[FIX] Corrects the location of the Whisper notification on the trading screen

### DIFF
--- a/BlockEQ/Coordinators/TradingCoordinator.swift
+++ b/BlockEQ/Coordinators/TradingCoordinator.swift
@@ -43,19 +43,10 @@ final class TradingCoordinator {
 
     var timer: Timer?
 
-    /// The view that handles all switching in the header
-    lazy var tradeHeaderView: TradeHeaderView = {
-        let rect = CGRect(origin: .zero, size: CGSize(width: UIScreen.main.bounds.size.width, height: 44.0))
-        let view = TradeHeaderView(frame: rect)
-        view.tradeHeaderViewDelegate = self
-        return view
-    }()
-
     lazy var navWrapper: AppNavigationController = {
         let wrapper = AppNavigationController(rootViewController: segmentController)
+        wrapper.navigationItem.largeTitleDisplayMode = .never
         wrapper.navigationBar.prefersLargeTitles = false
-        wrapper.navigationBar.addSubview(tradeHeaderView)
-
         return wrapper
     }()
 
@@ -228,14 +219,11 @@ extension TradingCoordinator {
     func displayTradeSuccess() {
         hideHud()
 
-        guard let navController = segmentController.navigationController else { return }
-
-        let message = Message(title: "TRADE_SUBMITTED".localized(), backgroundColor: Colors.green)
-        Whisper.show(whisper: message, to: navController, action: .show)
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            Whisper.hide(whisperFrom: navController)
-        }
+        let hud = MBProgressHUD.showAdded(to: segmentController.view, animated: true)
+        hud.mode = .text
+        hud.animationType = .zoom
+        hud.label.text = "TRADE_SUBMITTED".localized()
+        hud.hide(animated: true, afterDelay: 2)
     }
 
     func displayTradeError(_ error: FrameworkError) {
@@ -277,8 +265,7 @@ extension TradingCoordinator: AccountUpdatable {
 
 extension TradingCoordinator: TradeSegmentControllerDelegate {
     func setScroll(offset: CGFloat, page: Int) {
-        tradeHeaderView.sliderOriginConstraint.constant = offset
-        tradeHeaderView.setTitleSelected(index: page)
+
     }
 
     func displayAssetList() {
@@ -371,11 +358,5 @@ extension TradingCoordinator: MyOffersViewControllerDelegate {
 extension TradingCoordinator: OrderbookViewControllerDelegate {
     func requestedTogglePeriodicUpdates(enabled: Bool) {
         enabled ? startPeriodicOrderbookUpdates() : stopPeriodicOrderbookUpdates()
-    }
-}
-
-extension TradingCoordinator: TradeHeaderViewDelegate {
-    func switchedSegment(_ type: TradeSegment) -> Bool {
-        return segmentController.switchSegment(type)
     }
 }

--- a/BlockEQ/View Controllers/Trade/TradeSegmentViewController.swift
+++ b/BlockEQ/View Controllers/Trade/TradeSegmentViewController.swift
@@ -9,7 +9,6 @@
 import StellarHub
 
 protocol TradeSegmentControllerDelegate: AnyObject {
-    func setScroll(offset: CGFloat, page: Int)
     func displayAssetList()
 }
 
@@ -22,6 +21,13 @@ final class TradeSegmentViewController: UIViewController {
     var middleViewController: UIViewController!
     var totalPages: CGFloat!
     var displayNoAssetOverlay: Bool = true
+
+    lazy var tradeHeaderView: TradeHeaderView = {
+        let view = TradeHeaderView(frame: .zero)
+        view.tradeHeaderViewDelegate = self
+
+        return view
+    }()
 
     weak var tradeSegmentDelegate: TradeSegmentControllerDelegate?
 
@@ -69,6 +75,10 @@ final class TradeSegmentViewController: UIViewController {
     func setupView() {
         scrollView.backgroundColor = Colors.lightBackground
         noAssetView.isHidden = true
+
+        navigationController?.navigationBar.prefersLargeTitles = false
+        navigationItem.largeTitleDisplayMode = .never
+        navigationItem.titleView = tradeHeaderView
     }
 
     override func viewWillLayoutSubviews() {
@@ -134,6 +144,13 @@ extension TradeSegmentViewController: UIScrollViewDelegate {
         let scrollOffset = (scrollView.contentOffset.x / totalOffset) * scrollView.frame.size.width
         let page = Int(scrollView.contentOffset.x / scrollView.frame.size.width)
 
-        tradeSegmentDelegate?.setScroll(offset: scrollOffset, page: page)
+        tradeHeaderView.sliderOriginConstraint.constant = scrollOffset - 5
+        tradeHeaderView.setTitleSelected(index: page)
+    }
+}
+
+extension TradeSegmentViewController: TradeHeaderViewDelegate {
+    func switchedSegment(_ type: TradeSegment) -> Bool {
+        return switchSegment(type)
     }
 }

--- a/BlockEQ/Views/TradeHeaderView.swift
+++ b/BlockEQ/Views/TradeHeaderView.swift
@@ -23,7 +23,6 @@ protocol TradeHeaderViewDelegate: AnyObject {
 }
 
 class TradeHeaderView: UIView, NibOwnerLoadable {
-
     @IBOutlet weak var view: UIView!
     @IBOutlet weak var tradeButton: UIButton!
     @IBOutlet weak var orderBookButton: UIButton!
@@ -33,21 +32,19 @@ class TradeHeaderView: UIView, NibOwnerLoadable {
     var buttons: [UIButton] = []
     weak var tradeHeaderViewDelegate: TradeHeaderViewDelegate?
 
-    fileprivate static let nibName = "TradeHeaderView"
-
-    @IBAction func selectedButton(sender: UIButton) {
-        setSelected(selectedButton: sender, animated: true)
+    override var intrinsicContentSize: CGSize {
+        return UIView.layoutFittingExpandedSize
     }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.loadNibContent()
+        loadNibContent()
         setupView()
     }
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        self.loadNibContent()
+        loadNibContent()
         setupView()
     }
 
@@ -71,5 +68,12 @@ class TradeHeaderView: UIView, NibOwnerLoadable {
         if tradeHeaderViewDelegate?.switchedSegment(segment) == true {
             setTitleSelected(index: selectedButton.tag)
         }
+    }
+}
+
+// MARK: IBActions
+extension TradeHeaderView {
+    @IBAction func selectedButton(sender: UIButton) {
+        setSelected(selectedButton: sender, animated: true)
     }
 }

--- a/Podfile
+++ b/Podfile
@@ -43,12 +43,3 @@ target 'StellarHub' do
   end
 end
 
-#post_install do |installer|
-#  installer.pods_project.build_configurations.each do |config|
-#    if config.name == 'Release'
-#      config.build_settings['SWIFT_OPTIMIZATION_LEVEL'] = '-Owholemodule'
-#    else
-#      config.build_settings['SWIFT_OPTIMIZATION_LEVEL'] = '-Onone'
-#    end
-#  end
-#end


### PR DESCRIPTION
## Priority
Normal

## Description
This PR removes the Whisper notification from the trading screen. Since iOS introduced large titles, the Whisper library isn't playing nicely with them. 

I spent way too much time trying to offset the whisper library to work correctly. Rather than blowing more time on this to correct the content inset, I'm switching the Trade notification to use a simple `MBProgressHud` text instead. See attached screenshot.

## Screenshot
![fix](https://user-images.githubusercontent.com/728690/52447639-4c801400-2aff-11e9-9989-2c64ae4087c8.gif)