### PR TITLE
[FIX] PIN prompt when trading, core reset when switching wallets

### DIFF
--- a/BlockEQ/BlockEQWallet.swift
+++ b/BlockEQ/BlockEQWallet.swift
@@ -72,10 +72,11 @@ final class BlockEQWallet {
 
     func cleanupAppCoordinator() {
         appCoordinator = nil
+        core?.start()
     }
 
     func restartCore() {
-        self.core = CoreService(with: network)
+        core = CoreService(with: network)
     }
 
     func start() {

--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator+Extensions.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator+Extensions.swift
@@ -80,3 +80,11 @@ extension ApplicationCoordinator: DiagnosticCoordinatorDelegate {
     func completedDiagnostic(_ coordinator: DiagnosticCoordinator) {
     }
 }
+
+extension ApplicationCoordinator: TradingCoordinatorDelegate {
+    func requestedAuthentication(_ coordinator: TradingCoordinator, with options: AuthenticationCoordinator.AuthenticationOptions, authorized: EmptyCompletion?) {
+        displayAuth {
+            authorized?()
+        }
+    }
+}

--- a/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
+++ b/BlockEQ/Coordinators/Application/ApplicationCoordinator.swift
@@ -56,6 +56,8 @@ final class ApplicationCoordinator {
     // The coordinator responsible for the trading flow
     lazy var tradingCoordinator: TradingCoordinator = {
         let tradingCoordinator = TradingCoordinator(core: core)
+        tradingCoordinator.delegate = self
+
         return tradingCoordinator
     }()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Please keep this human readable! Omit classnames and technical details where possible.
 
-## [2.7.0] - 2019-02-06
+## [2.7.0] - 2019-02-07
 ### Added
-- Support to merge an account to a destionation account
+- Support to merge an account to a destination account
 
 ### Changed
 - Refactored the settings code into it's own coordinator class
+
+### Fixed
+- Fixed Whisper notifications from not displaying correctly when trading
+- Fixed a missing call to resubscribe services to receive notifications after switching wallets
 
 ## [2.6.2] - 2019-02-01
 ### Added

--- a/StellarHub/Services/CoreService.swift
+++ b/StellarHub/Services/CoreService.swift
@@ -45,7 +45,7 @@ public final class CoreService: CoreServiceProtocol {
         start()
     }
 
-    func start() {
+    public func start() {
         // Register the services to be notified when the account data is updated
         updateService.registerForUpdates(indexingService)
 

--- a/StellarHub/Services/IndexingService.swift
+++ b/StellarHub/Services/IndexingService.swift
@@ -96,6 +96,7 @@ public final class IndexingService: IndexingServiceProtocol {
     /// Removes the previously built index and starts again.
     public func rebuildIndex(for account: StellarAccount) {
         graph.clearEdges()
+        lastAccountIndexHash = 0
         updateIndex(for: account)
     }
 
@@ -108,6 +109,7 @@ public final class IndexingService: IndexingServiceProtocol {
     public func reset() {
         haltIndexing()
         graph.clear()
+        lastAccountIndexHash = 0
     }
 
     private func finishedIndexing(for account: StellarAccount) {


### PR DESCRIPTION
## Priority
Normal

## Description
This PR corrects an issue of the PIN challenge being disabled for trading. It originally was implemented, but must have been stomped in a refactor.

This also adds back a call to `start()` when resetting the wallet. This was preventing an account from being re-indexed when the wallet was switched.

## Screenshot
N/A