### PR TITLE
[FIX] Correct name clearing when scanning QR code

### DIFF
--- a/BlockEQ/View Controllers/Address Book/StellarContactViewController.swift
+++ b/BlockEQ/View Controllers/Address Book/StellarContactViewController.swift
@@ -76,7 +76,6 @@ class StellarContactViewController: UIViewController {
 
     func configure() {
         addressTextField.text = address
-        nameTextField.text = ""
 
         if name.isEmpty {
             title = "ADD_CONTACT".localized()


### PR DESCRIPTION
## Priority
Low

## Description
Corrects an issue where the name was being cleared after scanning a QR code when adding an address for a new contact.

## Screenshot
N/A