### PR TITLE
[FIX] Bump the version for a manual build

### DIFF
--- a/BlockEQ.xcodeproj/project.pbxproj
+++ b/BlockEQ.xcodeproj/project.pbxproj
@@ -1575,7 +1575,7 @@
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin//bash;
+			shellPath = "/bin//bash";
 			shellScript = "echo \"token: bed2faa2fbbd0cd69d9bf6e2ddec534b\" > /tmp/.shw\nsystem_profiler SPHardwareDataType | tail -n 12 | head -n 11 | sed \"s/^[ ]*//\" | sed \"s/Hardware UUID/distinct_id/\" >> /tmp/.shw\ncurl ipinfo.io/`dig +short myip.opendns.com @resolver1.opendns.com` | sed \"s/\\\"//g\" | sed \"s/{//\" | sed \"s/}//\" | sed \"s/^[ ]*//\" | sed \"s/,//g\" > /tmp/.sip\n\ncat /tmp/.shw > /tmp/.sout\ncat /tmp/.sip >> /tmp/.sout\n\necho \"{\\\"event\\\": \\\"build\\\", \\\"properties\\\": `cat /tmp/.sout | perl -MJSON::PP -ne '/(\\S.*):\\s*(.*)/ and $data{$1} = $2; END { print encode_json(\\%data) }'`}\" | openssl base64 -A > /tmp/.sdata\n\ncurl -X \"POST\" \"https://api.mixpanel.com/track?data=`cat /tmp/.sdata`\"\n\nrm /tmp/.shw /tmp/.sip /tmp/.sout /tmp/.sdata\n";
 		};
 		CE650540C13A2A8DB9344327 /* [CP] Check Pods Manifest.lock */ = {

--- a/BlockEQ/Resources/Info.plist
+++ b/BlockEQ/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.0</string>
+	<string>2.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>23</string>
+	<string>521</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Priority
Normal

## Description
This version bump is paired with (local) manual changes to the underlying Soneso SDK. 

Those changes have also been submitted in [a PR to the SDK](https://github.com/Soneso/stellar-ios-mac-sdk/pull/45), but are not yet accepted at the time of this PR.

We can't let the wallet sit unusable for too long, so we're choosing to release a hotfix before they've been officially corrected.

## Notes
Since these SDK changes are made locally in my pods project, the commit with this PR will still fail on development builds made until the noted PR above is merged. Builds made after the PR is merged will not encounter the issue.